### PR TITLE
wp_titleは非推奨になりました

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -91,6 +91,8 @@ function biz_vektor_theme_setup() {
 		'default-color' => '#ffffff',
 	) );
 
+	add_theme_support( 'title-tag' );
+
 	/*-------------------------------------------*/
 	/*	Admin page _ Eye catch
 	/*-------------------------------------------*/

--- a/header.php
+++ b/header.php
@@ -7,7 +7,6 @@ biz_vektor_get_theme_options(); ?>
 <html xmlns:fb="http://ogp.me/ns/fb#" <?php language_attributes(); ?>>
 <head>
 <meta charset="<?php bloginfo( 'charset' ); ?>" />
-<title><?php wp_title(); ?></title>
 <link rel="start" href="<?php echo home_url(); ?>" title="HOME" />
 <link rel="alternate" href="<?php echo home_url(); ?>" hreflang="<?php echo substr(get_bloginfo ( 'language' ), 0, 2);?>" />
 <!-- <?php echo get_biz_vektor_name();?> v<?php echo BizVektor_Theme_Version; ?> -->


### PR DESCRIPTION
WordPress 4.4よりwp_titleは非推奨になるよう。

add_theme_support( 'title-tag' );

https://core.trac.wordpress.org/changeset/35294
https://make.wordpress.org/core/2015/10/20/document-title-in-4-4/
https://github.com/kurudrive/Lightning/pull/48

(めんどくさかったので旧バージョン互換対策してないんですがこっちは絶対あっちとは違っている気がするのでそこらへんよろしくお願いします())
