### PR TITLE
【確認待ち】fix: deferの追加方法を変更

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -432,7 +432,6 @@ function bizVektorAddJsScripts() {
 }
 
 function bizVektor_add_defer_attribute( $tag, $handle ) {
-    // 'my-custom-script'ハンドルのスクリプトにのみdefer属性を追加
     if ( 'biz-vektor-min-js' === $handle ) {
         return str_replace( ' src', ' defer="defer" src', $tag );
     }

--- a/functions.php
+++ b/functions.php
@@ -431,15 +431,15 @@ function bizVektorAddJsScripts() {
 	wp_enqueue_script( 'biz-vektor-min-js' );
 }
 
-function bizVektor_add_defer_attribute($tag, $handle) {
+function bizVektor_add_defer_attribute( $tag, $handle ) {
     // 'my-custom-script'ハンドルのスクリプトにのみdefer属性を追加
-    if ('biz-vektor-min-js' === $handle) {
-        return str_replace(' src', ' defer="defer" src', $tag);
+    if ( 'biz-vektor-min-js' === $handle ) {
+        return str_replace( ' src', ' defer="defer" src', $tag );
     }
     return $tag;
 }
 
-add_filter('script_loader_tag', 'bizVektor_add_defer_attribute', 10, 2);
+add_filter( 'script_loader_tag', 'bizVektor_add_defer_attribute', 10, 2 );
 
 /*
 	Term list no link

--- a/functions.php
+++ b/functions.php
@@ -430,14 +430,16 @@ function bizVektorAddJsScripts() {
 	biz_vektor_set_localize_script();
 	wp_enqueue_script( 'biz-vektor-min-js' );
 }
-function add_defer_to_bizVektor_js( $url ) {
-	if ( false === strpos( $url, 'biz-vektor/js' ) or false === strpos( $url, '.js' ) ) { // not our file
-		return $url;
-	}
-	// Must be a ', not "!
-	return "$url' defer='defer";
+
+function bizVektor_add_defer_attribute($tag, $handle) {
+    // 'my-custom-script'ハンドルのスクリプトにのみdefer属性を追加
+    if ('biz-vektor-min-js' === $handle) {
+        return str_replace(' src', ' defer="defer" src', $tag);
+    }
+    return $tag;
 }
-add_filter( 'clean_url', 'add_defer_to_bizVektor_js', 11, 1 );
+
+add_filter('script_loader_tag', 'bizVektor_add_defer_attribute', 10, 2);
 
 /*
 	Term list no link

--- a/readme.txt
+++ b/readme.txt
@@ -32,6 +32,8 @@ http://bizvektor.com/contact/
 == Changelog ==
 https://github.com/kurudrive/biz-vektor/commits/master
 
+* [ Bug Fix ] Fixed issue with the process of adding the defer attribute
+
 == 1.12.5 ==
-* Support for PHP8 or highter
-* Support for WordPress 6.4
+* [ Specification Change ] Support for PHP8 or highter
+* [ Specification Change ] Support for WordPress 6.4


### PR DESCRIPTION
@kurudrive 

この部分で不具合を起こすことがあります。明らかに書き方がまずいので修正しました。
https://github.com/vektor-inc/biz-vektor/blob/9081b589293f37eb7656a74d15c7b540e3ae28c9/functions.php#L438

動くケースと動かないケースがあるのすが、MainWPでバージョン情報をremoveされることがあるようで、その場合にスクリプトがうまく読まれなくなったようです。

バージョン情報がremoveされスクリプトが読み込まれない
```HTML
<script type="text/javascript" src="https://rcjgifu-church.com/wp-content/themes/biz-vektor/js/biz-vektor-min.js' defer='defer" id="biz-vektor-min-js-js"></script>
```

これはなぜか読み込まれる
```HTML
<script type="text/javascript" src="https://hg-ch.jp/wp-content/themes/biz-vektor/js/biz-vektor-min.js?ver=1.9.14' defer='defer" id="biz-vektor-min-js-js"></script>
```

MainWP結構つかわれますし、たまたま読み込まれているだけで、適切なコードとは言えないので、書き直しました。
