### PR TITLE
【確認待ち】fix: コメント表示の不具合

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -445,7 +445,7 @@ add_filter( 'script_loader_tag', 'bizVektor_add_defer_attribute', 10, 2 );
 /*-------------------------------------------*/
 function get_the_term_list_nolink( $id = 0, $taxonomy = 'info-cat', $before = '', $sep = '', $after = '' ) {
 	$terms = get_the_terms( $id, $taxonomy );
-	if ( is_wp_error( $terms ) ) {
+	if ( is_fwp_error( $terms ) ) {
 		return $terms;
 	}
 	if ( empty( $terms ) ) {
@@ -539,6 +539,7 @@ if ( ! function_exists( 'biz_vektor_comment' ) ) :
 		$GLOBALS['comment'] = $comment;
 		switch ( $comment->comment_type ) :
 			case '':
+			case 'comment':
 				?>
 		<li <?php comment_class(); ?> id="li-comment-<?php comment_ID(); ?>">
 		<div id="comment-<?php comment_ID(); ?>" class="commentBox">

--- a/functions.php
+++ b/functions.php
@@ -445,7 +445,7 @@ add_filter( 'script_loader_tag', 'bizVektor_add_defer_attribute', 10, 2 );
 /*-------------------------------------------*/
 function get_the_term_list_nolink( $id = 0, $taxonomy = 'info-cat', $before = '', $sep = '', $after = '' ) {
 	$terms = get_the_terms( $id, $taxonomy );
-	if ( is_fwp_error( $terms ) ) {
+	if ( is_wp_error( $terms ) ) {
 		return $terms;
 	}
 	if ( empty( $terms ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -32,6 +32,7 @@ http://bizvektor.com/contact/
 == Changelog ==
 https://github.com/kurudrive/biz-vektor/commits/master
 
+* [ Big fix ] Fixed an issue where comments were not displaying after updating to WordPress 5.5.
 * [ Bug Fix ] Fixed issue with the process of adding the defer attribute
 
 == 1.12.5 ==


### PR DESCRIPTION
WordPress5.5以降コメントが表示されなくなっているのを修正しました。

https://blog.z0i.net/2020/11/comment-type.html