### PR TITLE
ctype_digit のエラー修正

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -774,7 +774,7 @@ function biz_vektor_set_localize_script() {
 	);
 
 	global $biz_vektor_options;
-	if ( isset( $biz_vektor_options['slider_slidespeed'] ) && ctype_digit( $biz_vektor_options['slider_slidespeed'] ) ) {
+	if ( isset( $biz_vektor_options['slider_slidespeed'] ) && ctype_digit( (string) $biz_vektor_options['slider_slidespeed'] ) ) {
 		$flexslider['slideshowSpeed'] = $biz_vektor_options['slider_slidespeed'];
 	}
 	if ( isset( $biz_vektor_options['slider_animation'] ) && $biz_vektor_options['slider_animation'] ) {


### PR DESCRIPTION
Deprecated: ctype_digit(): Argument of type int will be interpreted as string in the future in /var/www/html/wp-content/themes/biz-vektor/functions.php on line 777