### PR TITLE
[ 不具合修正 ] WordPress 6.7 以降で _load_textdomain_just_in_time の PHP 通知が表示される不具合を修正

### DIFF
--- a/design_skins/003/003_custom.php
+++ b/design_skins/003/003_custom.php
@@ -37,9 +37,23 @@ function is_rebuild(){
 	}
 }
 
-if (is_rebuild()){
-	require( dirname( __FILE__ ) . '/functions_003.php' );
+/**
+ * rebuild スキン用の関数ファイルを読み込む。
+ *
+ * is_rebuild() はテーマオプションを参照し、内部で __() による翻訳を行うため、
+ * ファイル読み込み時（after_setup_theme より前）に実行すると biz-vektor ドメインの
+ * 翻訳が init より前に呼び出され、_load_textdomain_just_in_time の doing_it_wrong 通知が
+ * 発生する。これを避けるため、翻訳読み込み（load_theme_textdomain）が完了した
+ * after_setup_theme のタイミングまで遅延させる。
+ *
+ * @return void
+ */
+function biz_vektor_rebuild_load_functions() {
+	if ( is_rebuild() ) {
+		require_once dirname( __FILE__ ) . '/functions_003.php';
+	}
 }
+add_action( 'after_setup_theme', 'biz_vektor_rebuild_load_functions' );
 
 /*-------------------------------------------*/
 /*	Admin page _ Add link bottom of pulldown

--- a/functions.php
+++ b/functions.php
@@ -139,7 +139,12 @@ function biz_vektor_theme_setup() {
 	register_nav_menus( array( 'FooterNavi' => 'Footer Navigation' ) );
 	register_nav_menus( array( 'FooterSiteMap' => 'Footer SiteMap' ) );
 
-	load_textdomain( 'biz-vektor', get_template_directory() . '/languages/ja.mo' );
+	// テーマの翻訳を読み込む。
+	// ロケールに応じて languages/{locale}.mo（ja.mo / zh_CN.mo 等）を読み込むため、
+	// ja.mo をハードコードせず load_theme_textdomain を使用する。
+	// after_setup_theme で読み込むことで、init 前に biz-vektor ドメインの翻訳へ
+	// アクセスされても just-in-time 読み込み（doing_it_wrong 通知）が発生しないようにする。
+	load_theme_textdomain( 'biz-vektor', get_template_directory() . '/languages' );
 
 	/*
 		Set content width

--- a/readme.txt
+++ b/readme.txt
@@ -32,6 +32,8 @@ http://bizvektor.com/contact/
 == Changelog ==
 https://github.com/kurudrive/biz-vektor/commits/master
 
+* [ 不具合修正 ] WordPress 6.7 以降で init より前に翻訳が読み込まれ _load_textdomain_just_in_time の PHP 通知が表示される不具合を修正
+
 == 1.13.1 ==
 * [ 不具合修正 ] WordPress 6.7 での翻訳不具合修正
 


### PR DESCRIPTION
## 概要

WordPress 6.7 以降で、`biz-vektor` テキストドメインの翻訳が `init` フックより前に読み込まれることで発生する `_load_textdomain_just_in_time` の PHP 通知（doing_it_wrong）を修正します。

close #335

## 原因

`design_skins/003/003_custom.php` がファイルスコープ（`functions.php` の file-scope `require` 経由 ＝ `after_setup_theme` より前）で `is_rebuild()` を呼び出しており、その内部でテーマオプションの既定値生成が走り `__( 'Blog', 'biz-vektor' )` に到達していました。テキストドメイン読み込み（`after_setup_theme`）より前に翻訳へアクセスするため、WordPress 6.7 で追加された just-in-time 読み込みの早期呼び出し警告が毎リクエスト発生していました。

## 修正内容

- **`design_skins/003/003_custom.php`**: ファイルスコープの `if ( is_rebuild() ) { require functions_003.php; }` を `biz_vektor_rebuild_load_functions()` に包み、`after_setup_theme` フックへ遅延。テキストドメイン読み込み後に `is_rebuild()`（翻訳アクセス）が走るようになり、通知を解消。`require` → `require_once` に変更し多重読み込みも防止。
- **`functions.php`**: `load_textdomain( 'biz-vektor', .../languages/ja.mo )`（`ja.mo` ハードコード）を `load_theme_textdomain( 'biz-vektor', get_template_directory() . '/languages' )` に置換。サイトロケールに応じて `ja.mo` / `zh_CN.mo` を読み分けるようになり、従来の「ロケールに関係なく常に日本語を読み込む」挙動も併せて是正。
- **`readme.txt`**: changelog 追記。

フック順序: `biz_vektor_theme_setup`（`functions.php:110`, テキストドメイン読み込み）が `after_setup_theme` 優先度10に先に登録され、`biz_vektor_rebuild_load_functions` は `003_custom.php` の file-scope require 時（同優先度）に後から登録されます。WordPress は同一優先度を登録順に実行するため「翻訳読み込み → `is_rebuild()` の翻訳アクセス」の順序が保証されます。

## テスト（確認手順）

前提: WordPress 6.7 以降 ＋ `wp-config.php` で `WP_DEBUG` / `WP_DEBUG_LOG` を有効化。本テーマを有効化しておく。

### Before（修正前・再現）

1. `master` の状態でフロントページ（`/`）にアクセスする
2. 続けて管理画面ダッシュボード（`/wp-admin/`）にアクセスする
3. `wp-content/debug.log` を確認する
   → `PHP Notice: Function _load_textdomain_just_in_time was called incorrectly. Translation loading for the biz-vektor domain was triggered too early ...` が記録される

### After（修正後・確認）

1. 本ブランチ（`fix/335-textdomain-notice`）を適用してテーマを有効化する
2. フロントページ（`/`）と管理画面ダッシュボード（`/wp-admin/`）にアクセスする
3. `wp-content/debug.log` を確認する
   → 上記 `_load_textdomain_just_in_time` の Notice が **記録されない**（該当行 0 件）
4. サイト言語を「日本語」にした状態で、`biz-vektor` ドメインの翻訳（例: `__( 'Blog', 'biz-vektor' )`）が「ブログ」と表示される
   → 翻訳は従来どおり機能する（`ja.mo` が正しく読み込まれる）

### デグレ確認

- デザインスキン「003（rebuild）」を有効にした状態で、`functions_003.php` によるカスタマイズ（ヘッダーのお問い合わせ表示・グローバルメニューの出力調整）が従来どおり適用されること
- PHP 7.4 / 8.0 / 8.2 / 8.3 / 8.4 で Fatal / Warning が発生しないこと（追加コードはプレーンな関数宣言・`add_action`・`require_once` のみで新構文なし）

## 備考

- 表示レイアウト・CSS の変更はないため Before/After スクリーンショットは省略します（変化は PHP 通知の消失のみ）。
- 新規追加関数 `biz_vektor_rebuild_load_functions()` はフック登録用のブートストラップ処理であり、かつ本テーマに PHPUnit 環境が存在しないため、単体テストは追加していません（`pull-request.md` のフック処理・テスト環境制約の除外に該当）。

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/235

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WordPress 6.7 以降で表示される翻訳読み込みに関する PHP 通知を修正しました。
  * テーマの翻訳ファイル読み込みを見直し、ロケールに応じた言語ファイルが適切なタイミングで読み込まれるようにしました。
  * 一部のスキンで、必要な機能読み込みを遅延実行するよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->