### PR TITLE
[ 開発環境 ] リリースワークフロー（3桁タグ push で GitHub Release 自動作成）を追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Release on Tag
+on:
+    push:
+        tags:
+            - '[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+    release:
+        name: GitHub Release
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        steps:
+            - uses: actions/checkout@v4
+            - name: Create Release
+              # softprops/action-gh-release v2.6.1 / v2
+              uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe
+              with:
+                  generate_release_notes: true


### PR DESCRIPTION
## 概要

biz-vektor はテーマ組み込みの PUC（[plugin-update-checker](https://github.com/YahnisElsts/plugin-update-checker)）が **最新 GitHub Release** を参照してテーマ更新を配信する構成です（`functions.php` の `Puc_v4_Factory::buildUpdateChecker(...)`）。しかしリリースワークフローが無く、GitHub Release は手動作成に依存していました。

3桁タグ（`X.X.X`）の push で GitHub Release を自動作成する `release.yml` を追加します。

## 変更内容

`.github/workflows/release.yml` を新設：

- トリガー: `[0-9]+.[0-9]+.[0-9]+`（3セグメント）のタグ push
- `softprops/action-gh-release`（SHA ピン留め）で GitHub Release を作成
- `generate_release_notes: true`（リリースノート自動生成）
- `permissions: contents: write`

### 設計方針

- biz-vektor はビルド工程を持たない（`package.json` は雛形のみ・ソース＝配布物）ため、build / dist / テストジョブは持たない**最小構成**にしています。
- `functions.php` の PUC は `enableReleaseAssets()` を呼んでいないため、更新パッケージは **GitHub が自動生成するタグのソース ZIP** になります。Release 作成時に配布物 ZIP を添付しない（`files:` 未指定）現状の挙動と整合します。`functions.php` は変更していません。

## 確認手順

1. この PR をマージ後、`master` で 3桁タグを打って push する
   ```
   git tag 1.13.2 && git push origin 1.13.2
   ```
   → Actions「Release on Tag」が起動し、GitHub Releases にタグ `1.13.2` の Release が作成される（リリースノート自動生成）
2. WordPress 管理画面（biz-vektor 有効化済みサイト）→ 外観 → テーマ
   → 新バージョンの更新通知が表示される（PUC が最新 Release を検知）

## 補足

- リリース手順を管理する `vk-agents` スキル側の対応（`github` 配信タイプの新設・承認済みリスト追加）は別 PR で対応済み（vektor-inc/vk-agents#169）。
- ワークフロー設定の追加のため changelog 記載は不要（vk-agents の changelog ルールより）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)