### PR TITLE
[ 不具合修正 ] 自動更新で vendor ディレクトリを含まないソース zip が配信され VkAdmin が動作しなくなる不具合を修正

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -91,7 +91,8 @@ $myUpdateChecker = Puc_v4_Factory::buildUpdateChecker(
 
 $myUpdateChecker->setBranch( 'master' );
 // GitHub 自動生成のソース zip（vendor 未同梱）ではなく、release.yml が添付する vendor 同梱の biz-vektor.zip を更新に使う.
-$myUpdateChecker->getVcsApi()->enableReleaseAssets( '/biz-vektor\.zip$/' );
+// 先頭・末尾アンカーで正確に biz-vektor.zip のみにマッチさせ、末尾一致の任意名アセットを拾わないようにする.
+$myUpdateChecker->getVcsApi()->enableReleaseAssets( '/^biz-vektor\.zip$/' );
 
 get_template_part( 'plugins/plugins' );
 require_once get_template_directory() . '/deprecations.php';

--- a/functions.php
+++ b/functions.php
@@ -90,6 +90,8 @@ $myUpdateChecker = Puc_v4_Factory::buildUpdateChecker(
 );
 
 $myUpdateChecker->setBranch( 'master' );
+// GitHub 自動生成のソース zip（vendor 未同梱）ではなく、release.yml が添付する vendor 同梱の biz-vektor.zip を更新に使う.
+$myUpdateChecker->getVcsApi()->enableReleaseAssets( '/biz-vektor\.zip$/' );
 
 get_template_part( 'plugins/plugins' );
 require_once get_template_directory() . '/deprecations.php';

--- a/readme.txt
+++ b/readme.txt
@@ -33,6 +33,7 @@ http://bizvektor.com/contact/
 https://github.com/kurudrive/biz-vektor/commits/master
 
 * [ 不具合修正 ] vendor ディレクトリが無い状態で誤配信された際に VkAdmin クラス未定義で Fatal Error になる不具合を修正
+* [ 不具合修正 ] 自動更新で vendor ディレクトリを含まないソース zip が配信され VkAdmin が動作しなくなる不具合を修正
 
 == 1.13.2 ==
 * [ 不具合修正 ] WordPress 6.7 以降で init より前に翻訳が読み込まれ _load_textdomain_just_in_time の PHP 通知が表示される不具合を修正

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -45,7 +45,10 @@ define( 'GUTENBERG_LOAD_VENDOR_SCRIPTS', false );
  * Manually load the plugin being tested.
  */
 function _manually_load_plugin() {
-	register_theme_directory( dirname( __FILE__ ) . '/../../' ); switch_theme('biz-vektor'); search_theme_directories();
+	// テーマのディレクトリ名を実際のフォルダ名から取得する.
+	// worktree 上ではフォルダ名が biz-vektor 以外になるため、固定値ではなく実フォルダ名でテーマを有効化する.
+	$theme_slug = basename( dirname( dirname( __FILE__ ) ) );
+	register_theme_directory( dirname( __FILE__ ) . '/../../' ); switch_theme( $theme_slug ); search_theme_directories();
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 

--- a/tests/test-sample.php
+++ b/tests/test-sample.php
@@ -18,9 +18,12 @@ class Sample_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * テスト環境で有効なテーマが biz-vektor であることを確認する。
+	 * テスト環境で BizVektor テーマが有効になっていることを確認する。
+	 *
+	 * テーマのフォルダ名は worktree 上では biz-vektor 以外になるため、
+	 * フォルダ名（stylesheet）ではなくテーマ名で判定する。
 	 */
 	public function test_active_theme() {
-		$this->assertEquals( 'biz-vektor', get_option( 'stylesheet' ), '有効なテーマが biz-vektor であること' );
+		$this->assertEquals( 'BizVektor', wp_get_theme()->get( 'Name' ), '有効なテーマが BizVektor であること' );
 	}
 }

--- a/tests/test-update-checker-release-assets.php
+++ b/tests/test-update-checker-release-assets.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Class Update_Checker_Release_Assets_Test
+ *
+ * functions.php で設定される自動更新チェッカー（Plugin Update Checker, PUC）が
+ * GitHub リリースの「添付アセット」を更新ファイルとして使う設定になっていることを検証するテスト。
+ *
+ * issue #349: enableReleaseAssets() を呼んでいないと PUC は GitHub 自動生成の
+ * ソース zip（zipball_url）を配信する。この zip には vendor ディレクトリが含まれないため、
+ * 更新後のサイトで Composer autoload が読み込めず VkAdmin が動作しなくなる不具合の回帰防止。
+ *
+ * @package Biz Vektor
+ */
+
+/**
+ * PUC のリリースアセット設定を検証するテストクラス。
+ */
+class Update_Checker_Release_Assets_Test extends WP_UnitTestCase {
+
+	/**
+	 * functions.php の enableReleaseAssets() 設定を検証する。
+	 *
+	 * - リリースアセットが有効化されていること（releaseAssetsEnabled = true）。
+	 * - アセット名フィルタ（assetFilterRegex）が release.yml の添付アセット名 biz-vektor.zip に
+	 *   マッチし、無関係なアセット名にはマッチしないこと。
+	 *
+	 * releaseAssetsEnabled / assetFilterRegex は protected プロパティ、
+	 * matchesAssetFilter() は protected メソッドのため Reflection で参照・実行する。
+	 */
+	public function test_enableReleaseAssets() {
+
+		// functions.php のロード時に設定されるグローバルの更新チェッカーを取得する.
+		global $myUpdateChecker;
+		$this->assertNotEmpty( $myUpdateChecker, 'functions.php で $myUpdateChecker が設定されていること' );
+
+		// 更新チェッカーから GitHub API インスタンスを取得する.
+		$api = $myUpdateChecker->getVcsApi();
+		$this->assertInstanceOf( 'Puc_v4p4_Vcs_GitHubApi', $api, '更新チェッカーが GitHub API を使用していること' );
+
+		// protected プロパティ・メソッドへアクセスするための Reflection を用意する.
+		$reflection = new ReflectionObject( $api );
+
+		$enabled_prop = $reflection->getProperty( 'releaseAssetsEnabled' );
+		$enabled_prop->setAccessible( true );
+
+		$matches_method = $reflection->getMethod( 'matchesAssetFilter' );
+		$matches_method->setAccessible( true );
+
+		// リリースアセットが有効化されていること.
+		// 未呼び出しだと zipball_url（vendor 無しのソース zip）が配信され、更新後に Fatal Error になる（issue #349）.
+		$this->assertTrue(
+			$enabled_prop->getValue( $api ),
+			'enableReleaseAssets() によりリリースアセットが有効化されていること（無効だと vendor 無しのソース zip が配信される）'
+		);
+
+		// テストの配列.
+		// asset_name : GitHub リリースに添付されたアセットのファイル名.
+		// expected   : そのアセット名がフィルタにマッチするか（true = 更新に使われる）.
+		$test_cases = array(
+			array(
+				'test_condition_name' => 'release.yml が添付する biz-vektor.zip => マッチ（vendor 同梱アセットが更新に使われる）',
+				'asset_name'          => 'biz-vektor.zip',
+				'expected'            => true,
+			),
+			array(
+				'test_condition_name' => '末尾が biz-vektor.zip のアセット名 => マッチ',
+				'asset_name'          => 'theme-biz-vektor.zip',
+				'expected'            => true,
+			),
+			array(
+				'test_condition_name' => 'GitHub 自動生成のソース zip 名（biz-vektor-1.13.2.zip）=> マッチしない（vendor 無し zip を除外）',
+				'asset_name'          => 'biz-vektor-1.13.2.zip',
+				'expected'            => false,
+			),
+			array(
+				'test_condition_name' => '無関係なアセット名（other.zip）=> マッチしない',
+				'asset_name'          => 'other.zip',
+				'expected'            => false,
+			),
+			array(
+				'test_condition_name' => '拡張子が異なる同名ファイル（biz-vektor.zip.bak）=> マッチしない（境界値）',
+				'asset_name'          => 'biz-vektor.zip.bak',
+				'expected'            => false,
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+			// PUC がアセット名フィルタに使う stdClass（name プロパティを持つ）を組み立てる.
+			$asset       = new stdClass();
+			$asset->name = $case['asset_name'];
+
+			// PUC 本体の matchesAssetFilter() で実際の判定挙動を検証する.
+			$actual = (bool) $matches_method->invoke( $api, $asset );
+
+			$this->assertSame( $case['expected'], $actual, $case['test_condition_name'] );
+		}
+	}
+}

--- a/tests/test-update-checker-release-assets.php
+++ b/tests/test-update-checker-release-assets.php
@@ -63,9 +63,9 @@ class Update_Checker_Release_Assets_Test extends WP_UnitTestCase {
 				'expected'            => true,
 			),
 			array(
-				'test_condition_name' => '末尾が biz-vektor.zip のアセット名 => マッチ',
+				'test_condition_name' => '先頭アンカーにより末尾一致の任意名アセット（theme-biz-vektor.zip）=> マッチしない',
 				'asset_name'          => 'theme-biz-vektor.zip',
-				'expected'            => true,
+				'expected'            => false,
 			),
 			array(
 				'test_condition_name' => 'GitHub 自動生成のソース zip 名（biz-vektor-1.13.2.zip）=> マッチしない（vendor 無し zip を除外）',


### PR DESCRIPTION
## 概要

自動更新（Plugin Update Checker, 以下 PUC）が **vendor ディレクトリを含まないソース zip** を配信するため、更新後のサイトで Composer autoload が読み込めず、VkAdmin（管理画面ダッシュボードウィジェット等）が動作しない不具合（#346 の Fatal Error の根本原因）を修正します。close #349

## 原因

`functions.php` の PUC 設定が `setBranch( 'master' )` のみで、リリースアセットを使う設定になっていませんでした。

- `Puc_v4p4_Vcs_GitHubApi::chooseReference('master')` は `getLatestRelease()` を使う。
- `getLatestRelease()` は既定で `downloadUrl` に `$release->zipball_url`（GitHub 自動生成のソースアーカイブ）を返す。このソース zip は #344 で gitignore された `vendor/` を含まない。
- 添付アセット（vendor 同梱の `biz-vektor.zip`）は `enableReleaseAssets()` を呼んだときだけ使われる。

結果、`release.yml` がタグ push 時に vendor 同梱 zip を作ってアセット添付しても、自動更新はそれを使わず vendor 無しのソース zip を配信 → vendor 欠落 → Fatal / VK 管理機能が動作しない、という状態でした。

## 修正内容

`functions.php` の PUC セットアップに、リリースアセットを使う設定を追加しました。

```php
$myUpdateChecker->getVcsApi()->enableReleaseAssets( '/^biz-vektor\.zip$/' );
```

- 正規表現は先頭・末尾アンカーで正確に `biz-vektor.zip` のみにマッチさせ、`evil-biz-vektor.zip` のような末尾一致の任意名アセットを拾わないようにしています（セキュリティレビュー指摘対応）。
- あわせて、この設定が回帰しないよう PHPUnit テスト（`tests/test-update-checker-release-assets.php`）を追加しました。PUC 本体の `matchesAssetFilter()` を実際に呼び、`biz-vektor.zip` のみマッチ・ソース zip 名（`biz-vektor-1.13.2.zip`）や末尾一致名は非マッチであることを検証します。
- テストを worktree 等フォルダ名が異なる環境でも成立させるため、`tests/bootstrap.php`・`tests/test-sample.php` のテーマ判定をフォルダ名非依存化しました（CI では従来と同一挙動）。

## テスト（確認手順）

### 自動テスト（PHPUnit）

1. `npm run phpunit` を実行する
   → `OK (4 tests, 23 assertions)` で全 PASS することを確認

**Before（修正前の再現）**: `functions.php` の `enableReleaseAssets` 行を削除した状態で `tests/test-update-checker-release-assets.php` を実行すると、`releaseAssetsEnabled` が `false` のため FAIL する（= 修正前は vendor 無しソース zip が配信される設定だったことを実証）。

**After（修正後）**: 上記テストが PASS する。

### コードでの確認

1. `functions.php` の PUC セットアップに `$myUpdateChecker->getVcsApi()->enableReleaseAssets( '/^biz-vektor\.zip$/' );` が追加されていることを確認
   → `chooseReference('master')` → `getLatestRelease()` の `if ( $this->releaseAssetsEnabled ... )` 分岐が有効になり、添付アセット `biz-vektor.zip` の `browser_download_url` が更新に使われる

### 実サイトでの検証（リリース後に要確認）

自動更新の挙動変更のため、この修正入りリリース作成後に以下を確認してください。

1. 実際にリリース（タグ push → `release.yml` で vendor 同梱 `biz-vektor.zip` がアセット添付される）を作成する
2. 既存サイトの自動更新を実行する
   → **vendor 同梱の `biz-vektor.zip` が配信される**（GitHub 自動生成のソース zip ではない）ことを確認
3. 更新後にダッシュボードウィジェット（VkAdmin）が正常表示されることを確認
   → 既にソース zip で更新済みの壊れたサイトも、この修正入りリリース以降の更新で回復する見込み

## 関連

- #346（症状の Fatal Error は #348 の `class_exists` ガードで多層防御として対応済み。本 PR はその根本原因の恒久対応）
- #344（vendor の git 除外・dist/release 基盤の追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/256