### PR TITLE
[ 開発環境 ] リリース zip のスモークテストを追加し検証済み zip をそのまま配布

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
 env:
     theme_name: biz-vektor
 
+permissions:
+    contents: read
+
 jobs:
     # 1. ソースツリーに対する PHP/WP フルマトリクスのユニットテスト（従来どおり）
     php_unit:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ env:
     theme_name: biz-vektor
 
 jobs:
+    # 1. ソースツリーに対する PHP/WP フルマトリクスのユニットテスト（従来どおり）
     php_unit:
         runs-on: ubuntu-latest
         permissions:
@@ -56,39 +57,145 @@ jobs:
               run: npx wp-env start && sudo chmod -R 777 ~/wp-env
             - name: Run PHP Unit Test
               run: npm run phpunit
-    release:
-        name: GitHub Release
+
+    # 2. 配布 zip をビルドし、展開済み dist をテーマとしてマウントしてスモークテスト
+    dist_smoke_test:
+        name: Dist Smoke Test
         runs-on: ubuntu-latest
-        needs: [php_unit]
-        permissions:
-            contents: write
         steps:
             - uses: actions/checkout@v4
               with:
                   persist-credentials: false
-            - name: Read .node-version
-              run: echo "{NODEVERSION}={$(cat .node-version)}" >> $GITHUB_OUTPUT
-              id: nodenv
             - name: Setup Node.js (.node-version)
               uses: actions/setup-node@v4
               with:
-                  node-version: '${{ steps.nodenv.outputs.NODEVERSION }}'
+                  node-version-file: '.node-version'
+                  cache: npm
             - name: Setup PHP 7.4
               uses: shivammathur/setup-php@v2
               with:
                   php-version: 7.4
+            - name: Get Composer cache directory
+              id: composer-cache
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+            - name: Cache Composer dependencies
+              uses: actions/cache@v4
+              with:
+                  path: ${{ steps.composer-cache.outputs.dir }}
+                  key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+                  restore-keys: ${{ runner.os }}-composer-
             - name: Install NPM Scripts
               run: npm install
-            - name: Install Composer Packages
-              run: composer install
-            - name: Build
-              run: npm run build
-            - name: Make Distribution
-              # npm run zip は最後に composer install(dev) を再実行するため、CI では --no-dev を確実にするため直書きにしている
+            - name: Install WP-CLI
               run: |
-                  composer install --no-dev
-                  npx gulp dist
-                  cd dist/ && zip -r ${{ env.theme_name }}.zip ${{ env.theme_name }}/
+                  curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+                  chmod +x wp-cli.phar
+                  mv wp-cli.phar /usr/local/bin/wp
+            - name: Create dist
+              # npm run dist = composer install --no-dev && gulp dist && composer install
+              # dist/biz-vektor には --no-dev の vendor（実配布物と同一）が入る
+              run: npm run dist
+            - name: Create zip
+              run: cd dist && zip -r ${{ env.theme_name }}.zip ${{ env.theme_name }}/
+            - name: Upload dist artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: dist
+                  path: dist/
+            - name: Setup wp-env for dist
+              run: |
+                  echo '{"core":null,"themes":["./dist/${{ env.theme_name }}"],"config":{"WP_DEBUG":true,"SCRIPT_DEBUG":true,"FS_METHOD":"direct"}}' > .wp-env.json
+            - name: Start wp-env
+              run: |
+                  for n in 1 2 3; do npx wp-env start --update && break || [ "$n" -lt 3 ] || exit 1; done
+                  sudo chmod -R 777 ~/wp-env
+            - name: Activate theme
+              run: npx wp-env run cli wp theme activate ${{ env.theme_name }}
+            - name: Smoke test
+              # vektor-inc/wp-actions main as of 2026-03-18
+              uses: vektor-inc/wp-actions/smoke-test@90f5a231bc956543bf235f36be4928d57af2edab
+            - name: Assert VkAdmin class is available in dist (positive assertion)
+              # 実 dist（--no-dev vendor）に対してクラス存在を陽性アサーション。
+              # dist_phpunit は vendor を dev で上書きするため #346 の vendor 欠落を検知できない。
+              # よってこの検知は vendor を上書きしない本ジョブ側で行う。
+              run: |
+                  npx wp-env run cli wp eval 'exit( class_exists("VektorInc\\VK_Admin\\VkAdmin") ? 0 : 1 );'
+
+    # 3. dist パッケージに対する PHPUnit（同梱 PHP ファイル群が実際に動くかの確認）
+    dist_phpunit:
+        name: Dist PHP Unit Test
+        runs-on: ubuntu-latest
+        needs: [dist_smoke_test]
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  persist-credentials: false
+            - name: Setup Node.js (.node-version)
+              uses: actions/setup-node@v4
+              with:
+                  node-version-file: '.node-version'
+                  cache: npm
+            - name: Setup PHP 7.4
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: 7.4
+            - name: Get Composer cache directory
+              id: composer-cache
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+            - name: Cache Composer dependencies
+              uses: actions/cache@v4
+              with:
+                  path: ${{ steps.composer-cache.outputs.dir }}
+                  key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+                  restore-keys: ${{ runner.os }}-composer-
+            - name: Install NPM Scripts
+              run: npm install
+            - name: Install Composer Packages (dev)
+              run: composer install
+            - name: Download dist artifact
+              uses: actions/download-artifact@v4
+              with:
+                  name: dist
+                  path: dist/
+            - name: Copy test dependencies into dist for phpunit
+              # dist の vendor（--no-dev）を dev vendor で上書きし、.phpunit.xml と tests を同梱する。
+              # ※ vendor を上書きするため vk-admin は常に存在してしまう → 配布物の vendor 欠落検知は
+              #   dist_smoke_test 側で担保している。
+              run: |
+                  rm -rf dist/${{ env.theme_name }}/vendor
+                  cp -rL vendor dist/${{ env.theme_name }}/vendor
+                  for f in .phpunit.xml phpunit.xml phpunit.xml.dist; do
+                    [ -f "$f" ] && cp "$f" "dist/${{ env.theme_name }}/$f" || true
+                  done
+                  [ -d tests ] && cp -r tests "dist/${{ env.theme_name }}/tests" || true
+                  ls dist/${{ env.theme_name }}/vendor/bin/phpunit && echo "phpunit OK" || echo "phpunit NOT FOUND"
+            - name: Setup wp-env for dist
+              # npm run phpunit は tests-cli を --env-cwd='wp-content/themes/biz-vektor' で実行するため、
+              # dist をデフォルトの .wp-env.json でその位置（basename=biz-vektor）にマウントして起動を揃える。
+              run: |
+                  echo '{"core":null,"themes":["./dist/${{ env.theme_name }}"],"config":{"WP_DEBUG":true,"SCRIPT_DEBUG":true,"FS_METHOD":"direct"}}' > .wp-env.json
+            - name: Start wp-env
+              run: |
+                  for n in 1 2 3; do npx wp-env start --update && break || [ "$n" -lt 3 ] || exit 1; done
+                  sudo chmod -R 777 ~/wp-env
+            - name: Run PHP Unit Test on dist
+              run: npm run phpunit
+
+    # 4. GitHub Release（再ビルドせず、2 が作った zip をそのまま添付）
+    release:
+        name: GitHub Release
+        runs-on: ubuntu-latest
+        needs: [php_unit, dist_smoke_test, dist_phpunit]
+        permissions:
+            contents: write
+        steps:
+            - name: Download dist artifact
+              uses: actions/download-artifact@v4
+              with:
+                  name: dist
+                  path: dist/
+            - name: Show checksum (audit)
+              run: sha256sum dist/${{ env.theme_name }}.zip
             - name: Create Release
               # softprops/action-gh-release v2.6.1 / v2
               uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe


### PR DESCRIPTION
## 概要

リリースされる zip が一度もスモークテストされていない構造的ギャップを塞ぎ、**スモークテストを通過した zip がそのままリリースファイルになる**ように `release.yml` を再構成します。

Closes #347

## 背景（なぜ必要か）

- #346 で、`npm run zip` のファイルは問題なかったのに **リリース版 zip で `VkAdmin` クラス未検出の Fatal Error が発生し、サイトが大量にダウン**した。
- 原因は `release.yml` の構造。`php_unit` ジョブは **dev 込みソースツリー**をテストする一方、`release` ジョブは **別途 `--no-dev` で zip を再ビルドして無検証のまま添付**していた。両者に差異（vendor 欠落など）があっても検知されず配布されていた。
- `dashboard-info-widget.php` は `is_admin()` ガードなしで無条件ロードされ `VkAdmin::init()` を呼ぶため、クラス欠落時はフロントも含め全ページが Fatal になる。

## 変更内容（`release.yml` の再構成）

VK Blocks Pro / Lightning Pro と同じ組織標準の構成に揃えました。

1. **`php_unit`（変更なし）** — ソースツリーの PHP/WP フルマトリクスのユニットテスト。
2. **`dist_smoke_test`（新設）** — `npm run dist` で zip を **1回だけビルド** → `upload-artifact` → 展開済み dist をテーマとして wp-env にマウント・有効化 → 共通アクション `vektor-inc/wp-actions/smoke-test`（SHA ピン）で HTTP スモーク → **実 dist（`--no-dev` vendor）に対する `class_exists('VektorInc\VK_Admin\VkAdmin')` の陽性アサーション**。
3. **`dist_phpunit`（新設）** — 同一 artifact を download し、dist の vendor を dev vendor で置換 + `tests/`・`.phpunit.xml` を同梱して PHPUnit を dist パッケージに対して実行（同梱 PHP ファイル群のパッケージング漏れ検知）。
4. **`release`（変更）** — **再ビルドせず**、`dist_smoke_test` が upload した artifact を download してそのまま添付（`sha256sum` 監査ログ付き）。テスト対象 zip == 配布 zip を構造的に保証。
5. トップレベルに既定 `permissions: contents: read` を追加し、`release` のみ `contents: write`（最小権限化）。

### 設計上のポイント

- **`class_exists` の陽性アサーションを `dist_smoke_test`（実 dist）側に置いた理由**: `dist_phpunit` は組織標準どおり dist の vendor を dev vendor で丸ごと上書きするため、そこで `class_exists` を見ても vk-admin は常に存在し、**vendor 欠落（#346 の本質）を検知できない偽陰性**になる。vendor を上書きしない `dist_smoke_test` 側で実 dist を検証する。
- **#346 の Fatal を防ぐ `class_exists` ガード修正（`dashboard-info-widget.php`）は本 PR の対象外**（#348 で対応済み）。本 PR は CI の構造ギャップ解消に専念。なおガードが入ったことで「フロントが落ちない＝安全」とは言えなくなった（クラス欠落でも静かにスキップされる）ため、上記の**陽性アサーションが再発検知の主役**になる。

## テスト（確認手順）

このワークフローは **3桁タグ（`x.y.z`）の push** で発火します。以下で検証できます。

### 1. 配布物に vk-admin が含まれることの確認（ローカル）

1. リポジトリルートで `npm run dist` を実行する
2. `ls dist/biz-vektor/vendor/vektor-inc/vk-admin/src/VkAdmin.php` を確認する
   → **ファイルが存在すること**（配布 zip に vk-admin が同梱される）
3. `php -r 'require "dist/biz-vektor/vendor/autoload.php"; var_export(class_exists("VektorInc\\VK_Admin\\VkAdmin"));'`
   → **`true`** が出力されること（実 dist の autoloader でクラスが解決できる）

### 2. スモークテストが #346 型の回帰を捕捉することの確認（ミューテーション検証・任意）

スモークテストが「素通り」でないことを確かめるには、意図的に壊して**失敗する**ことを確認します。

1. `npm run dist` 後、`rm -rf dist/biz-vektor/vendor/vektor-inc/vk-admin`（vk-admin を削除して #346 の状態を再現）
2. その dist をテーマとして wp-env にマウントし `wp eval 'exit( class_exists("VektorInc\\VK_Admin\\VkAdmin") ? 0 : 1 );'`
   → **exit code 1 で失敗すること**（＝ CI ではこの状態のリリースが `release` ジョブに到達せずブロックされる）
3. 削除を戻すと exit 0 に戻ること

### 3. CI 上での確認

- タグ push 時に `php_unit` → `dist_smoke_test` / `dist_phpunit`（並行）→ 全通過後に `release` が走る。
- `dist_smoke_test` または `dist_phpunit` が失敗すると `release` ジョブは実行されず、**壊れた zip はリリースされない**。

## デグレ確認

- `php_unit` ジョブは無変更のため既存のユニットテストの挙動に影響なし。
- 変更は `.github/workflows/release.yml` のみ。プロダクトコード（テーマ本体）への変更はなし。

## スクリーンショット

UI 変更なし（CI ワークフローのみ）のため省略。

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/253