### PR TITLE
[ 不具合修正 ] 固定ページ本文ウィジェットでタイトル表示のチェックを外して保存するとPHP 8以降で未定義キー警告が記録される不具合を修正

### DIFF
--- a/plugins/widgets/widgets.php
+++ b/plugins/widgets/widgets.php
@@ -189,7 +189,7 @@ class wp_widget_page extends WP_Widget {
 	function update($new_instance, $old_instance){
 		$instance = $old_instance;
 		$instance['page_id'] = $new_instance['page_id'];
-		$instance['set_title'] = ($new_instance['set_title'] == 'true')? true : false;
+		$instance['set_title'] = ( isset( $new_instance['set_title'] ) && $new_instance['set_title'] == 'true' )? true : false;
 		return $instance;
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -32,6 +32,8 @@ http://bizvektor.com/contact/
 == Changelog ==
 https://github.com/kurudrive/biz-vektor/commits/master
 
+* [ 不具合修正 ] 固定ページ本文ウィジェットで「タイトルを表示させる」のチェックを外して保存するとPHP 8以降で未定義キー警告が記録される不具合を修正
+
 == 1.13.3 ==
 * [ 不具合修正 ] vendor ディレクトリが無い状態で誤配信された際に VkAdmin クラス未定義で Fatal Error になる不具合を修正
 * [ 不具合修正 ] 自動更新で vendor ディレクトリを含まないソース zip が配信され VkAdmin が動作しなくなる不具合を修正


### PR DESCRIPTION
## 関連Issue
- 関連Issue: vektor-inc/multi-repo-tasks#23

## 変更の目的・理由
固定ページ本文ウィジェット（`wp_widget_page`）の保存処理 `update()` が、チェックボックス「タイトルを表示」の値を `isset` 無しで直接参照しているため、チェックを外して保存すると送信されないキーを読み、PHP 8.0 以降で `Undefined array key "set_title"` 警告がエラーログに記録される。ウィジェット保存のたびに発生するため防御的に修正する。

## 実装内容
`plugins/widgets/widgets.php` の `wp_widget_page::update()` 内、`set_title` の参照を `isset()` でガード。

- 原因: 未チェックのチェックボックスは POST に含まれないため、`$new_instance['set_title']` が未定義キー参照になる。
- 対策: `( isset( $new_instance['set_title'] ) && $new_instance['set_title'] == 'true' ) ? true : false` に変更。未チェック（キー不在）＝false、チェック（value='true'）＝true となり、**修正前後で保存値・表示は完全に不変**（出力不変の防御的修正）。

## テスト（確認手順）
対象テーマ **BizVektor** を有効化し、`WP_DEBUG` 有効・PHP 8.0 以降の環境で確認する。

### Before（修正前 / master）
1. 「外観 > ウィジェット」で固定ページ本文ウィジェット（display title のチェックがあるウィジェット）をウィジェットエリアに追加する → 設定フォームが表示される
2. 「タイトルを表示（display title）」の**チェックを外して**保存する → `wp-content/debug.log` に `Undefined array key "set_title" in .../plugins/widgets/widgets.php on line 192` が記録される

### After（修正後 / 本ブランチ）
3. 同じ操作（チェックを外して保存）を行う → 上記警告が debug.log に記録されない
4. チェックあり＝タイトル表示／チェックなし＝タイトル非表示、が修正前と同一であることを確認する → 保存値・フロント表示に変化なし（デグレなし）

補足（コードレベル実証）: PHP 8.4.7 で修正前=警告1件 / 修正後=0件を確認済み。

## 確認事項
- [x] 変更ファイルの内容を目視で確認済み（コード1行 ＋ changelog 1行のみ）
- [x] readme.txt にユーザー向け changelog を記載（版見出しなし）
- [x] PHP 8.4.7 で修正前後の再現（警告発生 → 消滅）を確認
- [x] 出力不変（保存値・フロント表示に変化なし）を確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 固定ページ本文ウィジェットで「タイトルを表示させる」をオフにして保存した際、PHP 8以降に未定義キー警告が発生する問題を修正しました。
  * タイトル表示設定が常に正しい真偽値として保存されるよう改善しました。

* **ドキュメント**
  * 上記の修正内容を変更履歴に追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->