### PR TITLE
[ 不具合修正 ] ブロック版ウィジェット編集画面で全幅見出しウィジェットの画像設定ボタンが機能しない問題を修正

### DIFF
--- a/plugins/widgets/js/admin-widget.js
+++ b/plugins/widgets/js/admin-widget.js
@@ -1,0 +1,29 @@
+/* global jQuery, wp */
+/**
+ * 背景画像登録処理
+ *
+ * @param {HTMLElement} e ボタン要素
+ */
+window.vk_title_bg_image_addiditional = function( e ) {
+	var d = jQuery( e ).parent().children( '._display' );
+	var w = jQuery( e ).parent().children( '._form' ).children( '.__id' )[ 0 ];
+	var u = wp.media( { library: { type: 'image' }, multiple: false } ).on( 'select', function() {
+		u.state().get( 'selection' ).each( function( f ) {
+			d.children().remove();
+			d.append( jQuery( '<img style="width:100%;height:auto">' ).attr( 'src', f.toJSON().url ) );
+			jQuery( w ).val( f.toJSON().id ).change();
+		} );
+	} );
+	u.open();
+};
+
+/**
+ * 背景画像削除処理
+ *
+ * @param {HTMLElement} e ボタン要素
+ */
+window.vk_title_bg_image_delete = function( e ) {
+	var d = jQuery( e ).parent().children( '._display' );
+	d.children().remove();
+	jQuery( e ).parent().children( '._form' ).children( '.__id' ).attr( 'value', '' ).change();
+};

--- a/plugins/widgets/widget-full-wide-title.php
+++ b/plugins/widgets/widget-full-wide-title.php
@@ -12,9 +12,25 @@ add_action(
 );
 // color picker js
 add_action( 'admin_enqueue_scripts', 'bv_full_wide_title_color_picker' );
-function bv_full_wide_title_color_picker() {
+/**
+ * ウィジェット管理画面でカラーピッカーとメディアライブラリ用スクリプトを読み込む
+ *
+ * @param string $hook 現在の管理画面のフック名。
+ */
+function bv_full_wide_title_color_picker( $hook ) {
+	if ( ! in_array( $hook, array( 'widgets.php', 'customize.php' ), true ) ) {
+		return;
+	}
 	wp_enqueue_style( 'wp-color-picker' );
 	wp_enqueue_script( 'wp-color-picker' );
+	wp_enqueue_media();
+	wp_enqueue_script(
+		'bv-widget-image-admin',
+		get_template_directory_uri() . '/plugins/widgets/js/admin-widget.js',
+		array( 'jquery' ),
+		'1.0.0',
+		true
+	);
 }
 add_action( 'admin_footer-widgets.php', 'bv_print_scripts_pr_color' );
 function bv_print_scripts_pr_color() {
@@ -112,39 +128,6 @@ class BV_Full_Wide_Title extends WP_Widget {
 	<input type="hidden" class="__id" name="<?php echo $this->get_field_name( 'media_image_id' ); ?>" value="<?php echo esc_attr( $instance['media_image_id'] ); ?>" />
 </div>
 </div>
-<script type="text/javascript">
-// 背景画像登録処理
-if ( vk_title_bg_image_addiditional == undefined ){
-var vk_title_bg_image_addiditional = function(e){
-		// プレビュー画像を表示するdiv
-	var d=jQuery(e).parent().children("._display");
-		// 画像IDを保存するinputタグ
-	var w=jQuery(e).parent().children("._form").children('.__id')[0];
-	var u=wp.media({library:{type:'image'},multiple:false}).on('select', function(e){
-		u.state().get('selection').each(function(f){
-					d.children().remove();
-					d.append(jQuery('<img style="width:100%;mheight:auto">').attr('src',f.toJSON().url));
-					jQuery(w).val(f.toJSON().id).change();
-				});
-	});
-	u.open();
-};
-}
-// 背景画像削除処理
-if ( vk_title_bg_image_delete == undefined ){
-var vk_title_bg_image_delete = function(e){
-		// プレビュー画像を表示するdiv
-		var d=jQuery(e).parent().children("._display");
-		// 画像IDを保存するinputタグ
-		var w=jQuery(e).parent().children("._form").children('.__id')[0];
-
-		// プレビュー画像のimgタグを削除
-		d.children().remove();
-		// w.attr("value","");
-		jQuery(e).parent().children("._form").children('.__id').attr("value","").change();
-};
-}
-</script>
 <?php
 		// title bg color
 		echo '<p class="color_picker_wrap">' .

--- a/readme.txt
+++ b/readme.txt
@@ -32,6 +32,8 @@ http://bizvektor.com/contact/
 == Changelog ==
 https://github.com/kurudrive/biz-vektor/commits/master
 
+* [ 不具合修正 ] ブロック版ウィジェット編集画面で全幅見出しウィジェットの画像設定ボタンが機能しない問題を修正
+
 == 1.13.3 ==
 * [ 不具合修正 ] vendor ディレクトリが無い状態で誤配信された際に VkAdmin クラス未定義で Fatal Error になる不具合を修正
 * [ 不具合修正 ] 自動更新で vendor ディレクトリを含まないソース zip が配信され VkAdmin が動作しなくなる不具合を修正


### PR DESCRIPTION
## 関連Issue
- 関連Issue: https://github.com/vektor-inc/multi-repo-tasks/issues/28


## 変更の目的・理由

ブロック版ウィジェット編集画面（外観 > ウィジェット）で、全幅見出しウィジェットの「背景画像を設定」「背景画像を削除」ボタンをクリックしてもメディアライブラリが開かない不具合を修正します。

ウィジェットの `form()` メソッドが HTML 内にインライン `<script>` タグでJS関数を定義していたため、ブロック版ウィジェット編集画面が動的にフォーム HTML を挿入する際にインラインスクリプトが実行されず、`ReferenceError` が発生していました。

## 実装内容

### 主な変更点
- [x] バグ修正

### 技術的な詳細

- `plugins/widgets/widget-full-wide-title.php` の `form()` メソッド内のインライン `<script>` タグを削除
- 同ファイルの `bv_full_wide_title_color_picker()` 関数に `$hook` パラメータを追加し、`widgets.php` / `customize.php` 画面のみで `wp_enqueue_media()` と外部JSファイルを読み込むように変更
- `plugins/widgets/js/admin-widget.js` を新規作成し、`vk_title_bg_image_addiditional`（背景画像登録処理）と `vk_title_bg_image_delete`（背景画像削除処理）をグローバル関数として定義

## スクリーンショット
（UI変更なし・動作のみの修正のため省略）

---
## レビュワー向け情報

### テスト手順

#### Before（修正前の再現手順）

1. WordPress 管理画面で「外観 > ウィジェット」を開く
2. 「全幅見出し」ウィジェットを任意のウィジェットエリアに追加する
3. ウィジェット設定内の「背景画像を設定」ボタンをクリックする
4. → メディアライブラリが開かない（ブラウザコンソールに `ReferenceError` が出力される）

#### After（修正後の期待動作）

1. 同じ手順でウィジェットを追加する
2. 「背景画像を設定」ボタンをクリックする
3. → メディアライブラリが開き、画像を選択・設定できる
4. 「背景画像を削除」ボタンをクリックする
5. → 設定した画像が削除される

#### 既存ユーザーへの影響確認

5. 修正前にウィジェットに画像を保存済みの環境でも、保存済みの画像IDが正常に表示・削除できることを確認する

#### カラーピッカーの動作確認

6. 全幅見出しウィジェットのカラーピッカーが引き続き正常に動作することを確認する（`bv_full_wide_title_color_picker()` の変更による回帰確認）

### レビューポイント（任意）
- `bv_full_wide_title_color_picker()` の `$hook` パラメータ追加が既存のカラーピッカー動作に影響しないこと
