### PR TITLE
[ 不具合修正 ] 日付アーカイブのパンくずリストで日付部分が <span> タグごと文字列として表示される不具合を修正

### DIFF
--- a/module_panList.php
+++ b/module_panList.php
@@ -127,7 +127,10 @@ if ( ( is_single() || is_archive() ) && ! is_post_type_archive() ) {
 
 if ( is_date() ) {
 	$breadcrumb_array[] = array(
-		'name'             => get_the_archive_title(),
+		// get_the_archive_title() は WordPress 5.5 以降、日付部分を <span> で囲んだ
+		// HTML を返すため、esc_html() でそのまま出すとタグが文字列表示されてしまう。
+		// wp_strip_all_tags() でタグを除去してからプレーンテキストとして格納する.
+		'name'             => wp_strip_all_tags( get_the_archive_title() ),
 		'id'               => '',
 		'url'              => '',
 		'class_additional' => '',

--- a/module_panList.php
+++ b/module_panList.php
@@ -129,7 +129,7 @@ if ( is_date() ) {
 	$breadcrumb_array[] = array(
 		// get_the_archive_title() は WordPress 5.5 以降、日付部分を <span> で囲んだ
 		// HTML を返すため、esc_html() でそのまま出すとタグが文字列表示されてしまう。
-		// wp_strip_all_tags() でタグを除去してからプレーンテキストとして格納する.
+		// wp_strip_all_tags() でタグを除去してからプレーンテキストとして格納する。
 		'name'             => wp_strip_all_tags( get_the_archive_title() ),
 		'id'               => '',
 		'url'              => '',

--- a/module_panList_old.php
+++ b/module_panList_old.php
@@ -262,7 +262,10 @@ if ( is_404() ) {
 			$panListHtml      .= '<li' . $microdata_li . '><a href="' . home_url() . '/' . $post_type . '/"' . $microdata_li_a . '><span' . $microdata_li_a_span . '>' . $current_post_type->label . '</span></a> &raquo; </li>';
 		}
 
-		$panListHtml .= '<li><span>' . esc_html( get_the_archive_title() ) . '</span></li>';
+		// get_the_archive_title() は WordPress 5.5 以降、日付部分を <span> で囲んだ
+		// HTML を返すため、esc_html() でそのまま出すとタグが文字列表示されてしまう。
+		// wp_strip_all_tags() でタグを除去してから esc_html() する（順序が逆だと意味が無い）。
+		$panListHtml .= '<li><span>' . esc_html( wp_strip_all_tags( get_the_archive_title() ) ) . '</span></li>';
 
 	} elseif ( is_day() ) {
 		//is_dayの場合

--- a/readme.txt
+++ b/readme.txt
@@ -33,6 +33,7 @@ http://bizvektor.com/contact/
 https://github.com/kurudrive/biz-vektor/commits/master
 
 * [ 不具合修正 ] 固定ページ本文ウィジェットで「タイトルを表示させる」のチェックを外して保存するとPHP 8以降で未定義キー警告が記録される不具合を修正
+* [ 不具合修正 ] 日付アーカイブのパンくずリストで日付部分が `<span>` タグごと文字列として表示される不具合を修正
 
 == 1.13.3 ==
 * [ 不具合修正 ] vendor ディレクトリが無い状態で誤配信された際に VkAdmin クラス未定義で Fatal Error になる不具合を修正

--- a/tests/test-module-panlist.php
+++ b/tests/test-module-panlist.php
@@ -21,70 +21,120 @@ class Module_PanList_Test extends WP_UnitTestCase {
 	 * 日付アーカイブ（年別・月別・日別）へ go_to() した状態で
 	 * module_panList.php を include し、出力されるパンくずリストの HTML に
 	 * エスケープされた <span> タグ（&lt;span&gt;）が含まれないこと、
-	 * および get_the_archive_title() のタグを除去したプレーンテキストが
-	 * 含まれることを検証する。
+	 * および期待するプレーンテキストが含まれることを検証する。
+	 *
+	 * 期待値はプロダクションコードと同じ式（wp_strip_all_tags( get_the_archive_title() )）
+	 * で作らず、リテラルの文字列で持つ。同一式同士の比較にすると、
+	 * 万が一 name が空文字へ退行しても assertStringContainsString( '', $html ) が
+	 * 無条件に true になり、テストが素通りしてしまうため。
 	 */
 	public function test_module_panList() {
 
-		// 2023-01-15 の投稿を1件作成する.
-		// go_to() で年別・月別・日別アーカイブ URL へ移動しても、
-		// 該当する日付の投稿が無いと 404（is_date() が false）になってしまうため、
-		// 年・月・日すべてのアーカイブに共通してヒットする投稿をあらかじめ用意する.
-		self::factory()->post->create(
-			array(
-				'post_date'   => '2023-01-15 12:00:00',
-				'post_status' => 'publish',
-			)
-		);
+		// 期待値をリテラルの英語文言で持たせるため、テスト中のロケールを
+		// en_US に固定する（wp-env のテスト環境は既定で en_US だが、
+		// 環境差で落ちないよう明示的に固定する）.
+		// アサーション失敗時も含め、必ず元のロケールへ戻すため try/finally で囲む.
+		switch_to_locale( 'en_US' );
 
-		// テストの配列.
-		// url_callback: is_date() 分岐へ到達させるための対象 URL を生成するコールバック.
-		$test_cases = array(
-			array(
-				'test_condition_name' => '年別アーカイブの場合 => <span> タグが文字列表示されずプレーンテキストになる',
-				'url_callback'        => function () {
-					return get_year_link( 2023 );
-				},
-			),
-			array(
-				'test_condition_name' => '月別アーカイブの場合 => <span> タグが文字列表示されずプレーンテキストになる',
-				'url_callback'        => function () {
-					return get_month_link( 2023, 1 );
-				},
-			),
-			array(
-				'test_condition_name' => '日別アーカイブの場合（境界値） => <span> タグが文字列表示されずプレーンテキストになる',
-				'url_callback'        => function () {
-					return get_day_link( 2023, 1, 15 );
-				},
-			),
-		);
+		try {
 
-		foreach ( $test_cases as $case ) {
+			// 2023-01-15 の投稿を1件作成する.
+			// go_to() で年別・月別・日別アーカイブ URL へ移動しても、
+			// 該当する日付の投稿が無いと 404（is_date() が false）になってしまうため、
+			// 年・月・日すべてのアーカイブに共通してヒットする投稿をあらかじめ用意する.
+			self::factory()->post->create(
+				array(
+					'post_date'   => '2023-01-15 12:00:00',
+					'post_status' => 'publish',
+				)
+			);
 
-			// 対象の日付アーカイブ URL へ移動しクエリを構築する.
-			$this->go_to( call_user_func( $case['url_callback'] ) );
+			// テストの配列.
+			// target_url    : is_date() 分岐へ到達させるための対象 URL（クエリに依存しないため事前に評価できる）.
+			// title_filter  : get_the_archive_title の戻り値を差し替える第三者フィルタ（null なら差し替えない）.
+			// expected      : module_panList.php の出力に含まれるべきプレーンテキストのリテラル値.
+			$test_cases = array(
+				array(
+					'test_condition_name' => '年別アーカイブの場合 => <span> タグが除去されプレーンテキストになる',
+					'target_url'          => get_year_link( 2023 ),
+					'title_filter'        => null,
+					'expected'            => 'Year: 2023',
+				),
+				array(
+					'test_condition_name' => '月別アーカイブの場合 => <span> タグが除去されプレーンテキストになる',
+					'target_url'          => get_month_link( 2023, 1 ),
+					'title_filter'        => null,
+					'expected'            => 'Month: January 2023',
+				),
+				array(
+					'test_condition_name' => '日別アーカイブの場合 => <span> タグが除去されプレーンテキストになる',
+					'target_url'          => get_day_link( 2023, 1, 15 ),
+					'title_filter'        => null,
+					'expected'            => 'Day: January 15, 2023',
+				),
+				array(
+					'test_condition_name' => '異常系: 第三者フィルタが属性付きタグと script を返す場合 => タグも script の中身も除去される',
+					'target_url'          => get_year_link( 2023 ),
+					'title_filter'        => '<span class="x">2023</span><script>alert(1)</script>年鑑',
+					'expected'            => '2023年鑑',
+				),
+			);
 
-			// 前提条件として is_date() 分岐へ入ることを確認する.
-			$this->assertTrue( is_date(), $case['test_condition_name'] . '（前提: is_date() が true であること）' );
+			foreach ( $test_cases as $case ) {
 
-			// 期待するプレーンテキスト（WordPress コア関数の出力からタグを除去したもの）.
-			// module_panList.php と同じリクエストコンテキストで呼ぶため、
-			// 翻訳文言やロケールの違いに依存せず比較できる.
-			$expected_plain_text = wp_strip_all_tags( get_the_archive_title() );
+				// テストケース自体の前提: expected が空文字でないこと.
+				// ここが空だと assertStringContainsString( '', $html ) が無条件に true になり、
+				// name が空文字へ退行してもテストが素通りしてしまうため、先に潰しておく.
+				$this->assertNotEmpty( $case['expected'], $case['test_condition_name'] . '（テストケース自体の前提: expected が空でないこと）' );
 
-			// header.php から get_template_part('module_panList') で呼ばれるのと同様に
-			// module_panList.php を include し、出力をキャプチャする.
-			ob_start();
-			include get_stylesheet_directory() . '/module_panList.php';
-			$breadcrumb_html = ob_get_clean();
+				// 第三者フィルタで get_the_archive_title() の戻り値を差し替えるケース.
+				// アサーション失敗時も含め、必ずフィルタを外すため try/finally で囲む.
+				$title_filter_callback = null;
+				if ( null !== $case['title_filter'] ) {
+					$fixed_title           = $case['title_filter'];
+					$title_filter_callback = function () use ( $fixed_title ) {
+						return $fixed_title;
+					};
+					add_filter( 'get_the_archive_title', $title_filter_callback );
+				}
 
-			// <span> タグがエスケープされて文字列表示されないこと（不具合の直接的な症状）.
-			$this->assertStringNotContainsString( '&lt;span&gt;', $breadcrumb_html, $case['test_condition_name'] . '（&lt;span&gt; が含まれないこと）' );
-			$this->assertStringNotContainsString( '&lt;/span&gt;', $breadcrumb_html, $case['test_condition_name'] . '（&lt;/span&gt; が含まれないこと）' );
+				try {
 
-			// タグを除去したプレーンテキストが breadcrumb 内に含まれること.
-			$this->assertStringContainsString( esc_html( $expected_plain_text ), $breadcrumb_html, $case['test_condition_name'] . '（プレーンテキストが含まれること）' );
+					// 対象の日付アーカイブ URL へ移動しクエリを構築する.
+					$this->go_to( $case['target_url'] );
+
+					// 前提条件として is_date() 分岐へ入ることを確認する.
+					$this->assertTrue( is_date(), $case['test_condition_name'] . '（前提: is_date() が true であること）' );
+
+					// header.php から get_template_part('module_panList') で呼ばれるのと同様に
+					// module_panList.php を include し、出力をキャプチャする.
+					// 無名関数でスコープを閉じることで、テンプレート内で使われるローカル変数
+					// （$post_type, $breadcrumb_array, $key, $value, $microdata_li 等）が
+					// テストメソッドのスコープへ漏れないようにする.
+					$breadcrumb_html = ( function () {
+						ob_start();
+						include get_stylesheet_directory() . '/module_panList.php';
+						return ob_get_clean();
+					} )();
+
+					// <span> タグ・script タグがエスケープされて文字列表示されないこと（不具合の直接的な症状）.
+					$this->assertStringNotContainsString( '&lt;span&gt;', $breadcrumb_html, $case['test_condition_name'] . '（&lt;span&gt; が含まれないこと）' );
+					$this->assertStringNotContainsString( '&lt;/span&gt;', $breadcrumb_html, $case['test_condition_name'] . '（&lt;/span&gt; が含まれないこと）' );
+					$this->assertStringNotContainsString( '&lt;script&gt;', $breadcrumb_html, $case['test_condition_name'] . '（&lt;script&gt; が含まれないこと）' );
+
+					// リテラルの期待値（プロダクションコードと同一の式で作らない）が含まれること.
+					$this->assertStringContainsString( esc_html( $case['expected'] ), $breadcrumb_html, $case['test_condition_name'] . '（期待するプレーンテキストが含まれること）' );
+
+				} finally {
+					// 次のケースへ影響させないよう必ずフィルタを外す.
+					if ( null !== $title_filter_callback ) {
+						remove_filter( 'get_the_archive_title', $title_filter_callback );
+					}
+				}
+			}
+		} finally {
+			// ロケールを元に戻す.
+			restore_current_locale();
 		}
 	}
 }

--- a/tests/test-module-panlist.php
+++ b/tests/test-module-panlist.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Class Module_PanList_Test
+ *
+ * module_panList.php の日付アーカイブ（年別・月別・日別）分岐で、
+ * get_the_archive_title() が返す HTML（<span> タグ）がそのまま
+ * esc_html() され、画面に文字列として表示されてしまう不具合の回帰テスト。
+ *
+ * issue #353: 日付アーカイブのパンくずリストで
+ * `年: <span>2023年</span>` のように <span> タグが文字列表示される不具合の回帰防止。
+ *
+ * @package Biz Vektor
+ */
+
+/**
+ * module_panList.php の日付アーカイブ分岐を検証するテストクラス。
+ */
+class Module_PanList_Test extends WP_UnitTestCase {
+
+	/**
+	 * 日付アーカイブ（年別・月別・日別）へ go_to() した状態で
+	 * module_panList.php を include し、出力されるパンくずリストの HTML に
+	 * エスケープされた <span> タグ（&lt;span&gt;）が含まれないこと、
+	 * および get_the_archive_title() のタグを除去したプレーンテキストが
+	 * 含まれることを検証する。
+	 */
+	public function test_module_panList() {
+
+		// 2023-01-15 の投稿を1件作成する.
+		// go_to() で年別・月別・日別アーカイブ URL へ移動しても、
+		// 該当する日付の投稿が無いと 404（is_date() が false）になってしまうため、
+		// 年・月・日すべてのアーカイブに共通してヒットする投稿をあらかじめ用意する.
+		self::factory()->post->create(
+			array(
+				'post_date'   => '2023-01-15 12:00:00',
+				'post_status' => 'publish',
+			)
+		);
+
+		// テストの配列.
+		// url_callback: is_date() 分岐へ到達させるための対象 URL を生成するコールバック.
+		$test_cases = array(
+			array(
+				'test_condition_name' => '年別アーカイブの場合 => <span> タグが文字列表示されずプレーンテキストになる',
+				'url_callback'        => function () {
+					return get_year_link( 2023 );
+				},
+			),
+			array(
+				'test_condition_name' => '月別アーカイブの場合 => <span> タグが文字列表示されずプレーンテキストになる',
+				'url_callback'        => function () {
+					return get_month_link( 2023, 1 );
+				},
+			),
+			array(
+				'test_condition_name' => '日別アーカイブの場合（境界値） => <span> タグが文字列表示されずプレーンテキストになる',
+				'url_callback'        => function () {
+					return get_day_link( 2023, 1, 15 );
+				},
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+
+			// 対象の日付アーカイブ URL へ移動しクエリを構築する.
+			$this->go_to( call_user_func( $case['url_callback'] ) );
+
+			// 前提条件として is_date() 分岐へ入ることを確認する.
+			$this->assertTrue( is_date(), $case['test_condition_name'] . '（前提: is_date() が true であること）' );
+
+			// 期待するプレーンテキスト（WordPress コア関数の出力からタグを除去したもの）.
+			// module_panList.php と同じリクエストコンテキストで呼ぶため、
+			// 翻訳文言やロケールの違いに依存せず比較できる.
+			$expected_plain_text = wp_strip_all_tags( get_the_archive_title() );
+
+			// header.php から get_template_part('module_panList') で呼ばれるのと同様に
+			// module_panList.php を include し、出力をキャプチャする.
+			ob_start();
+			include get_stylesheet_directory() . '/module_panList.php';
+			$breadcrumb_html = ob_get_clean();
+
+			// <span> タグがエスケープされて文字列表示されないこと（不具合の直接的な症状）.
+			$this->assertStringNotContainsString( '&lt;span&gt;', $breadcrumb_html, $case['test_condition_name'] . '（&lt;span&gt; が含まれないこと）' );
+			$this->assertStringNotContainsString( '&lt;/span&gt;', $breadcrumb_html, $case['test_condition_name'] . '（&lt;/span&gt; が含まれないこと）' );
+
+			// タグを除去したプレーンテキストが breadcrumb 内に含まれること.
+			$this->assertStringContainsString( esc_html( $expected_plain_text ), $breadcrumb_html, $case['test_condition_name'] . '（プレーンテキストが含まれること）' );
+		}
+	}
+}

--- a/tests/test-module-panlist.php
+++ b/tests/test-module-panlist.php
@@ -33,6 +33,8 @@ class Module_PanList_Test extends WP_UnitTestCase {
 		// 期待値をリテラルの英語文言で持たせるため、テスト中のロケールを
 		// en_US に固定する（wp-env のテスト環境は既定で en_US だが、
 		// 環境差で落ちないよう明示的に固定する）.
+		// なお switch_to_locale() は現在のロケールが既に指定先と同じ場合は
+		// 切り替え不要のため false を返す no-op になる（本環境では通常この経路）。
 		// アサーション失敗時も含め、必ず元のロケールへ戻すため try/finally で囲む.
 		switch_to_locale( 'en_US' );
 


### PR DESCRIPTION
Closes #353

@coderabbitai ignore

## 概要

日付アーカイブ（年別・月別・日別）のパンくずリストで、日付部分が `<span>` タグごと文字列として画面に表示されてしまう不具合を修正しました。

**修正前の表示**

```
HOME » お知らせ 年: <span>2023年</span>
```

**修正後の表示**

```
HOME » お知らせ » 年: 2023年
```

## 原因

パンくずリストを組み立てるテンプレート `module_panList.php` は、各項目の表示名をいったん配列（`$breadcrumb_array`）に平文で溜めておき、最後にまとめて HTML へ組み立てるつくりになっています。組み立てる段階では、溜めた表示名を HTML として解釈されないように無害化する処理（`esc_html()`。`<` などの記号を画面表示用の文字に置き換える WordPress の関数）を通します。

日付アーカイブの分岐では、この表示名として `get_the_archive_title()`（アーカイブページの見出し文字列を返す WordPress の関数）の戻り値をそのまま入れていました。ところが **この関数は WordPress 5.5 以降、日付部分を `<span>` で囲んだ HTML を返すよう変更されています**（[core changeset #47950](https://core.trac.wordpress.org/changeset/47950) / [ticket #37041](https://core.trac.wordpress.org/ticket/37041)）。

そのため「平文が入っている前提」が崩れ、`<span>` が無害化処理でそのまま文字に変換されて、タグが画面に見えてしまっていました。

## 発生条件

以下の両方を満たすときに発生します。

1. WordPress 5.5 以降
2. 子テーマで `module_panList.php` を上書きしていない（＝親テーマのパンくずテンプレートが使われる）

子テーマ側で `module_panList.php` を独自に上書きしているサイトでは発現しません。

## 修正内容

表示名として溜める前にタグを取り除く処理（`wp_strip_all_tags()`。文字列から HTML タグを除去する WordPress の関数）を通し、他の分岐と同じ「平文」の状態に揃えてから配列へ入れるようにしました。

```php
// 修正前
'name' => get_the_archive_title(),

// 修正後
'name' => wp_strip_all_tags( get_the_archive_title() ),
```

日付の書式・「年: 」などの見出し文言・翻訳は WordPress 本体に任せたままなので、表記が独自実装に置き換わることはありません。

### 変更ファイル

| ファイル | 内容 |
|---|---|
| `module_panList.php` | 日付アーカイブ分岐でタグを除去してから表示名を格納するよう変更（原因と対処のインラインコメントを追加） |
| `tests/test-module-panlist.php`（新規） | 回帰テストを追加。年別・月別・日別の正常系3ケースと、他プラグインが見出し文字列を書き換えた場合を想定した異常系1ケース |
| `readme.txt` | changelog に1行追記 |

### 副次的な改善

- **構造化データ**: このパンくずは検索エンジン向けの構造化データ（schema.org の BreadcrumbList。パンくずの階層を機械に伝えるための印）を出力しています。修正前は項目名を示す `itemprop="name"` の値に生のタグ文字列が混入しており、壊れたデータを出力している状態でした。これが解消されます。
- **アクセシビリティ**: 画面読み上げソフトが「山カッコ、span、山カッコ、2023年…」と読み上げていた状態が解消されます。

## 確認手順

### 前提条件

- WordPress 5.5 以降
- 子テーマで `module_panList.php` を上書きしていないこと
- 同じ年月日に投稿が1件以上あること（例: 2023年1月15日）

### 手順

#### Before（修正前の再現手順）

1. 修正前のコード（`master`）の状態で、投稿が存在する年の年別アーカイブを開く（例: `https://<サイトURL>/?m=2023`）
2. ページ上部のパンくずリストを見る
   → ✗ `年: <span>2023年</span>` のように `<span>` タグが文字として表示される
3. 月別アーカイブ（`?m=202301`）・日別アーカイブ（`?m=20230115`）でも同様に確認する
   → ✗ いずれも `<span>` タグが文字として表示される

#### After（修正後）

1. このブランチを適用した状態で、同じ年別アーカイブを開く（`?m=2023`）
2. ページ上部のパンくずリストを見る
   → ✓ `年: 2023年` とだけ表示され、`<span>` の文字は出ない
3. 月別アーカイブ（`?m=202301`）を開く
   → ✓ `月: 2023年1月` とだけ表示される
4. 日別アーカイブ（`?m=20230115`）を開く
   → ✓ `日: 2023年1月15日` とだけ表示される

#### デグレ確認（他のパンくず表示が変わっていないこと）

5. カテゴリーアーカイブを開く
   → ✓ 修正前と同じくカテゴリー名が表示される（親カテゴリーがある場合は階層も従来どおり）
6. タグアーカイブ・カスタムタクソノミーのアーカイブを開く
   → ✓ 修正前と同じ表示
7. 固定ページ（親子階層のあるページを含む）を開く
   → ✓ 修正前と同じ表示
8. 個別投稿ページ・検索結果ページ・404 ページを開く
   → ✓ 修正前と同じ表示

#### 自動テスト

9. `npm run phpunit` を実行する
   → ✓ 全テストが通る（実測: `OK (5 tests, 47 assertions)`）

## スクリーンショット

日本語環境の年別アーカイブ（`?m=2023`）で、同じ画面・同じ条件で撮影したものです。

### Before（修正前）

![Before: 年別アーカイブ](https://github.com/vektor-inc/review-assets/blob/main/biz-vektor/pr-362/before-year-archive.png?raw=true)

パンくずに `年: <span>2023年</span>` とタグが文字として出ています。

### After（修正後）

![After: 年別アーカイブ](https://github.com/vektor-inc/review-assets/blob/main/biz-vektor/pr-362/after-year-archive.png?raw=true)

`年: 2023年` とだけ表示されます。

<details>
<summary>月別・日別アーカイブ、デグレ確認（クリックで展開）</summary>

**月別アーカイブ（`?m=202301`）— `月: 2023年1月`**

![After: 月別アーカイブ](https://github.com/vektor-inc/review-assets/blob/main/biz-vektor/pr-362/after-month-archive.png?raw=true)

**日別アーカイブ（`?m=20230115`）— `日: 2023年1月15日`**

![After: 日別アーカイブ](https://github.com/vektor-inc/review-assets/blob/main/biz-vektor/pr-362/after-day-archive.png?raw=true)

**デグレ確認: カテゴリーアーカイブ（親子階層）**

![デグレ確認: カテゴリーアーカイブ](https://github.com/vektor-inc/review-assets/blob/main/biz-vektor/pr-362/regression-category-archive.png?raw=true)

**デグレ確認: 固定ページ（親子階層）**

![デグレ確認: 固定ページ](https://github.com/vektor-inc/review-assets/blob/main/biz-vektor/pr-362/regression-child-page.png?raw=true)

</details>

> 画像の保存先 `vektor-inc/review-assets` は非公開リポジトリのため、アクセス権のない方には表示されません。

## 補足

- 本体の変更は実質1行で、画面へ出力されうる文字列の幅が狭まる方向の変更です
- 読み込まれていない旧ファイル `module_panList_old.php` にも同種の記述が残っていますが、`header.php` から読み込まれるのは `module_panList.php` のみのため、本 PR では触っていません

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/695
