### PR TITLE
[ 開発環境 ] Dependabot の依存更新を安全なものだけ自動マージする設定を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,80 @@
+# Dependabot の設定
+#
+# 依存関係の更新 PR を毎週作成する。開発依存（ビルド・テスト用）の minor / patch 更新は
+# 1 本の PR にまとめ、dependabot-auto-merge ワークフローで CI 通過後に自動マージする。
+# 本番依存（配布物に含まれるライブラリ）と major 更新はグループに入らず個別の PR になり、
+# 人が確認する。
+version: 2
+
+updates:
+  # ---------------------------------------------------------------------------
+  # npm
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: build
+      prefix-development: build
+      include: scope
+    groups:
+      npm-development:
+        applies-to: version-updates
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+
+  # ---------------------------------------------------------------------------
+  # Composer
+  # 開発依存（phpcs / PHPUnit 用）は配布物に含まれないため、まとめて自動マージ対象にする。
+  # 本番依存（vendor/ に入って配布されるもの）は changelog への記載が必要なため、
+  # グループに入れず個別の PR にする。
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: build
+      prefix-development: build
+      include: scope
+    groups:
+      composer-development:
+        applies-to: version-updates
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+
+  # ---------------------------------------------------------------------------
+  # GitHub Actions
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: build
+      include: scope
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/dependabot-auto-merge-complete.yml
+++ b/.github/workflows/dependabot-auto-merge-complete.yml
@@ -1,0 +1,98 @@
+# dependabot-auto-merge.yml が「自動マージ対象」と判定した PR を、CI 完了後にマージする。
+#
+# workflow_run はデフォルトブランチにあるこのファイルが使われるため、
+# Dependabot のブランチ側を書き換えてもマージ処理は変わらない。
+name: Dependabot auto-merge complete
+
+on:
+  workflow_run:
+    workflows:
+      - "PHP Unit Test"
+    types:
+      - completed
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  merge:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 対象の PR をマージ
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+
+          # CI のジョブがすべて実際に成功したかを確かめる。
+          # run 全体の結論は「一部のジョブが skip、残りが成功」でも success になるため、
+          # 条件付きで skip されたジョブがあるとテストを実行していない PR がマージされうる。
+          # ジョブが 1 つも無い run（すべて skip）もここで弾く。
+          jobs_json=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100")
+          job_count=$(echo "$jobs_json" | jq '.jobs | length')
+          not_success=$(echo "$jobs_json" \
+            | jq -r '[.jobs[] | select(.conclusion != "success") | "\(.name)=\(.conclusion)"] | join(", ")')
+          if [ "$job_count" = "0" ] || [ -n "$not_success" ]; then
+            echo "CI のジョブが成功していないため終了する（jobs: ${job_count} / 未成功: ${not_success:-なし}）"
+            exit 0
+          fi
+
+          pr=$(gh pr list \
+            --repo "$REPO" \
+            --head "$HEAD_BRANCH" \
+            --state open \
+            --json number,headRefOid,labels,author \
+            --jq '.[0]')
+
+          if [ -z "$pr" ] || [ "$pr" = "null" ]; then
+            echo "ブランチ ${HEAD_BRANCH} に対応する open な PR が無いため終了する"
+            exit 0
+          fi
+
+          number=$(echo "$pr" | jq -r '.number')
+          author=$(echo "$pr" | jq -r '.author.login')
+          head_oid=$(echo "$pr" | jq -r '.headRefOid')
+          labeled=$(echo "$pr" | jq -r '[.labels[].name] | index("dependabot-auto-merge") != null')
+
+          if [ "$author" != "app/dependabot" ] && [ "$author" != "dependabot[bot]" ]; then
+            echo "#${number} は Dependabot の PR ではないため終了する（author: ${author}）"
+            exit 0
+          fi
+
+          if [ "$labeled" != "true" ]; then
+            echo "#${number} に dependabot-auto-merge ラベルが無いため終了する"
+            exit 0
+          fi
+
+          # CI が走った時点と PR の先頭コミットがずれている場合は、
+          # 新しいコミットに対する CI の完了を待つ
+          if [ "$head_oid" != "$HEAD_SHA" ]; then
+            echo "#${number} の先頭コミットが CI 実行時から変わっているため終了する"
+            echo "  CI: ${HEAD_SHA} / PR: ${head_oid}"
+            exit 0
+          fi
+
+          # base ブランチが動いているとマージが弾かれることがあるため数回試す。
+          # ここで失敗しても Dependabot が rebase すると CI が再実行され、
+          # この workflow がもう一度呼ばれるので取りこぼしにはならない。
+          for attempt in 1 2 3; do
+            if gh pr merge "$number" --repo "$REPO" --squash --delete-branch \
+              --match-head-commit "$HEAD_SHA"; then
+              echo "#${number} をマージした"
+              exit 0
+            fi
+            echo "マージに失敗した（${attempt} 回目）。20 秒後に再試行する"
+            sleep 20
+          done
+
+          echo "#${number} のマージに失敗した。Dependabot の rebase 後に再試行される"
+          exit 1

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,27 +1,123 @@
+# Dependabot の PR が自動マージしてよい内容かを判定し、該当すればラベルを付ける。
+# 実際のマージは CI 完了後に dependabot-auto-merge-complete.yml が行う。
+#
+# 判定を「PR が開いた時点」、マージを「CI が終わった時点」に分けているのは、
+# gh pr merge --auto が必須ステータスチェックの無いブランチでは CI の完了を待たず
+# その場でマージしてしまうため。
 name: Dependabot auto-merge
 
-on: pull_request
+on:
+  pull_request:
+    branches:
+      - master
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
+  issues: write
 
 jobs:
-  auto-merge:
+  judge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
     steps:
-      - name: Fetch Dependabot metadata
+      - name: Dependabot のメタデータを取得
         id: meta
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
 
-      - name: Enable auto-merge for devDeps/indirect minor/patch
-        if: |
-          (steps.meta.outputs.dependency-type == 'direct:development' ||
-           steps.meta.outputs.dependency-type == 'indirect') &&
-          (steps.meta.outputs.update-type == 'version-update:semver-minor' ||
-           steps.meta.outputs.update-type == 'version-update:semver-patch')
-        run: gh pr merge --auto --squash "$PR_URL"
+      - name: 自動マージの可否を判定
+        id: judge
         env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
+          DEP_TYPE: ${{ steps.meta.outputs.dependency-type }}
+          UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
+          DEP_GROUP: ${{ steps.meta.outputs.dependency-group }}
+          DEP_NAMES: ${{ steps.meta.outputs.dependency-names }}
+          ECOSYSTEM: ${{ steps.meta.outputs.package-ecosystem }}
+        run: |
+          set -euo pipefail
+
+          ok=false
+          reason="判定条件のいずれにも当てはまらないため"
+
+          if [ -n "$DEP_GROUP" ]; then
+            # グループ更新。dependabot.yml 側で minor / patch に限定しているグループのみ許可する
+            case "$DEP_GROUP" in
+              npm-development|composer-development|github-actions)
+                ok=true
+                reason="グループ ${DEP_GROUP} は minor / patch のみを含む設定のため"
+                ;;
+              *)
+                reason="グループ ${DEP_GROUP} は自動マージの対象に登録されていないため"
+                ;;
+            esac
+          elif [ -n "$UPDATE_TYPE" ]; then
+            # 単一パッケージの更新。依存の種類と更新レベルで判定する
+            level="${UPDATE_TYPE#version-update:semver-}"
+            case "$DEP_TYPE" in
+              direct:development)
+                if [ "$level" = "minor" ] || [ "$level" = "patch" ]; then
+                  ok=true
+                  reason="開発依存の ${level} 更新のため"
+                else
+                  reason="開発依存だが ${level} 更新のため"
+                fi
+                ;;
+              indirect)
+                # Composer の推移的依存は vendor/ に入って配布されるうえ、
+                # fetch-metadata では本番依存から到達したものか判別できないため人が確認する。
+                if [ "$ECOSYSTEM" = "composer" ]; then
+                  reason="Composer の推移的依存は配布物に含まれ、依存元を判別できないため"
+                elif [ "$level" = "minor" ] || [ "$level" = "patch" ]; then
+                  ok=true
+                  reason="推移的依存の ${level} 更新のため"
+                else
+                  reason="推移的依存だが ${level} 更新のため"
+                fi
+                ;;
+              direct:production)
+                if [ "$ECOSYSTEM" = "github-actions" ]; then
+                  # GitHub Actions は配布物に含まれないが、fetch-metadata は
+                  # direct:production を返すためここに来る。判断は開発依存と同じでよい。
+                  if [ "$level" = "minor" ] || [ "$level" = "patch" ]; then
+                    ok=true
+                    reason="GitHub Actions の ${level} 更新のため"
+                  else
+                    reason="GitHub Actions だが ${level} 更新のため"
+                  fi
+                else
+                  # Font Awesome や Swiper など配布物に含まれるライブラリは
+                  # changelog への記載が必要なので人が確認する
+                  reason="配布物に含まれるライブラリの更新は changelog への記載が必要なため"
+                fi
+                ;;
+              *)
+                reason="依存の種類が判定できないため（dependency-type: ${DEP_TYPE:-空}）"
+                ;;
+            esac
+          else
+            # 複数パッケージをまとめた PR では update-type が取得できず、
+            # major 更新が混ざっていても見分けられないため人が確認する。
+            reason="複数パッケージをまとめた PR で更新レベルが判定できないため"
+          fi
+
+          echo "対象パッケージ: ${DEP_NAMES}"
+          echo "dependency-type: ${DEP_TYPE:-（なし）} / update-type: ${UPDATE_TYPE:-（なし）} / group: ${DEP_GROUP:-（なし）}"
+          echo "自動マージ: ${ok}（${reason}）"
+          echo "ok=${ok}" >> "$GITHUB_OUTPUT"
+
+      - name: 自動マージ対象のラベルを付ける
+        if: steps.judge.outputs.ok == 'true'
+        env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          gh label create dependabot-auto-merge \
+            --repo "$REPO" \
+            --color 0e8a16 \
+            --description "CI 通過後に自動マージする Dependabot の PR" \
+            2>/dev/null || true
+          # gh pr edit --add-label は組織スコープ不足で失敗することがあるため REST API を使う
+          gh api "repos/${REPO}/issues/${PR_NUMBER}/labels" \
+            -X POST -f "labels[]=dependabot-auto-merge" --silent

--- a/composer.json
+++ b/composer.json
@@ -8,5 +8,10 @@
         "yoast/phpunit-polyfills": "^1.1.0",
         "vektor-inc/vk-wp-unit-test-tools": "^0.10.0",
         "doctrine/instantiator": "^1.5.0"
+    },
+    "config": {
+        "platform": {
+            "php": "7.4"
+        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e48af56a8fc8f3f412e2d78cfe04f728",
+    "content-hash": "f3d65a90e09ecbdbdc6b31bcfc5fb09a",
     "packages": [
         {
             "name": "vektor-inc/vk-admin",
@@ -2008,5 +2008,8 @@
     "prefer-lowest": false,
     "platform": {},
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "7.4"
+    },
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Refs vektor-inc/multi-repo-tasks#42（Dependabot の自動マージのしくみを各リポジトリへ展開する issue）

## 概要

Dependabot（依存ライブラリの更新 PR を自動で作る GitHub のしくみ）が作る PR のうち、開発用の依存（ビルド・テスト用のパッケージ）の小さな更新だけを、CI（GitHub Actions によるテストの自動実行）が通ったあとに自動でマージするようにします。vk-blocks-pro で運用している構成（vektor-inc/vk-blocks-pro#3126 で導入、vektor-inc/vk-blocks-pro#3148 で「一部のジョブがスキップされただけでも成功扱いになる」問題を修正したもの）を、biz-vektor に合わせて入れたものです。

登場するものが 4 つあるので、先に役割とつながりを示します。

| 名前 | 何をするものか |
|---|---|
| Dependabot（`.github/dependabot.yml`） | 毎週月曜に依存の更新 PR を作る。開発用の依存の minor / patch 更新（バージョン番号の 2 桁目・3 桁目だけが上がる小さな更新。1 桁目が上がるのが major 更新）は 1 本の PR にまとめる |
| judge（`.github/workflows/dependabot-auto-merge.yml`） | Dependabot の PR が開いた時点で「自動マージしてよい内容か」を判定し、該当すれば `dependabot-auto-merge` ラベルを付ける |
| ゲート CI（既存の `.github/workflows/php_unit_test.yml`、名前 `PHP Unit Test`） | PHPUnit（PHP の自動テスト）を PHP 7.4 / 8.0 / 8.2 × WordPress 6.7 / 6.8 の 6 ジョブで実行する。途中で `npm run build`（gulp によるビルド）も実行する |
| complete（`.github/workflows/dependabot-auto-merge-complete.yml`） | ゲート CI の完了をきっかけに起動し、ラベル付きの PR を CI 成功後にマージする |

```mermaid
flowchart LR
  dep["Dependabot<br>更新 PR を作る"] --> judge["judge<br>判定してラベルを付ける"]
  dep --> ci["ゲート CI（PHP Unit Test）<br>6 ジョブでテストとビルド"]
  ci -- 完了イベント --> complete["complete<br>ラベル付きなら<br>全ジョブ成功を確認してマージ"]
  judge -. ラベル .-> complete
```

### なぜ judge と complete の 2 段に分けるか

biz-vektor の `master` ブランチには必須ステータスチェック（マージ前に通っていなければならない CI の指定）が設定されていません。これまでの `dependabot-auto-merge.yml` は GitHub の自動マージ機能（`gh pr merge --auto`）を使っていましたが、この機能は必須ステータスチェックが無いブランチでは CI の完了を待たずにその場でマージしてしまいます。そのため「判定してラベルを付ける」と「CI が終わってからマージする」を別のワークフローに分けています。

## 何がどう変わるか

### 1. Dependabot の設定を追加（`.github/dependabot.yml`）

これまでこのリポジトリには Dependabot の設定ファイルが無く、セキュリティ更新の PR だけが作られていました。以下の 3 つのパッケージ管理について、毎週月曜 9:00（日本時間）に更新 PR を作るようにします。

| 対象 | まとめ方 |
|---|---|
| npm（`package.json`） | 開発用の依存（`devDependencies`）の minor / patch 更新を `npm-development` グループとして 1 本の PR にまとめる |
| Composer（`composer.json`） | 開発用の依存（`require-dev`。PHPUnit 用のパッケージ）の minor / patch 更新を `composer-development` グループとして 1 本の PR にまとめる |
| GitHub Actions（`.github/workflows/*.yml` で使うアクション） | minor / patch 更新を `github-actions` グループとして 1 本の PR にまとめる |

本番用の依存（配布物に含まれるライブラリ。Composer の `vektor-inc/vk-admin` など）と major 更新はグループに入らず、個別の PR になります。

### 2. 自動マージするかどうかを判定する（`.github/workflows/dependabot-auto-merge.yml`）

既存のファイルを丸ごと置き換えています。判定は PR が開いた時点で行い、結果と理由をワークフローのログに出力します。

| 更新の内容 | 自動マージ |
|---|---|
| グループ更新（`npm-development` / `composer-development` / `github-actions`） | する（設定側で minor / patch に限定しているため） |
| 開発用の依存（`direct:development`）の minor / patch 更新 | する |
| 開発用の依存の major 更新 | しない |
| 推移的依存（直接指定していないが、依存の依存として入るもの。`indirect`）の minor / patch 更新（npm / GitHub Actions） | する |
| 推移的依存の更新（Composer） | しない（`vendor/` に入って配布されるうえ、本番用の依存から来たものか判別できないため） |
| GitHub Actions の単体の minor / patch 更新 | する（配布物に含まれないため） |
| 本番用の依存（`direct:production`）の更新 | しない（changelog への記載が必要なため） |
| 複数パッケージをまとめた PR でグループ名が無いもの | しない（major が混ざっていても見分けられないため） |

自動マージ対象と判定した PR には `dependabot-auto-merge` ラベルを付けます（ラベルが無ければ作ります）。

### 3. CI 通過後にマージする（`.github/workflows/dependabot-auto-merge-complete.yml`）

ゲート CI は既存の `PHP Unit Test` です。理由は次の 2 点です。

- このワークフローは `run-ci` ラベル（多くのリポジトリで、付けたときだけ重い CI が動くラベル）に関係なく、`master` / `develop` 向けのすべての PR で動く作りになっているため、Dependabot の PR でもそのまま動く
- PHPUnit の実行に加えて `npm run build`（gulp によるビルド）も実行するため、npm の依存更新でビルドが壊れていないかの検証も兼ねる

complete は次の順に確認して、すべて満たすときだけマージします（複数のコミットを 1 つにまとめる squash マージで、マージ後にブランチは削除）。

1. CI のジョブ 6 つがすべて `success` である（skip や failure が 1 つでもあれば終了）
2. 同じブランチに open な PR があり、作成者が Dependabot である
3. その PR に `dependabot-auto-merge` ラベルが付いている
4. PR の先頭コミットが、CI を実行したコミットと一致している（CI 実行後に Dependabot が rebase していた場合は、新しいコミットの CI 完了を待つ）

このリポジトリの CI は `PHP Unit Test` の 1 本だけなので、対象外にしたワークフローはありません（`Release on Tag` はタグを付けたときだけ動くリリース用のワークフローなので、PR のゲートにはなりません）。

### 4. Dependabot の PR で CI が走るようにする

該当しません。上記のとおり `PHP Unit Test` は既存のままで Dependabot の PR でも動くため、CI の新設も条件変更もしていません。

### 5. composer.json に対象 PHP を明示

`composer.json` の `config` に `"platform": { "php": "7.4" }` を追加しました。Dependabot は PHP 8 の環境で `composer update`（依存の更新）を実行するため、対象 PHP を明示していないと PHP 8 必須のパッケージが `composer.lock`（実際に入れるバージョンを固定するファイル）に入り、PHP 7.4 で動かす CI が落ちます（vk-blocks-pro で実際に起きました）。`7.4` は `PHP Unit Test` のマトリクスの下限です。

`composer update --lock --no-install`（パッケージは入れ替えず lock ファイルだけ更新するコマンド）を実行した結果、`composer.lock` の変更は `content-hash`（`composer.json` の内容から計算する値）と `platform-overrides`（対象 PHP の記録）の 2 か所だけで、パッケージのバージョンは 1 つも変わっていません。

## 判断が分かれる点

なし。テンプレートの判定ロジックはそのまま使っています。

## 気づいた点（この PR では変更しない）

- `php_unit_test.yml` と `release.yml` の「Read .node-version」ステップが `echo "{NODEVERSION}={$(cat .node-version)}" >> $GITHUB_OUTPUT` となっており、後続ステップへ値を渡すファイル（`$GITHUB_OUTPUT`）に書く書式が `name=value` の形になっていません。このため後続の `actions/setup-node`（Node.js を用意するアクション）に渡す `node-version`（使う Node.js の版）は空になり、`.node-version` の `20.14.0` ではなくランナー既定の Node で動いていると思われます。現状 CI は通っているので実害は出ていませんが、Node の版を固定したい場合は `echo "NODEVERSION=$(cat .node-version)" >> "$GITHUB_OUTPUT"` に直す必要があります。
- `composer validate` は通りますが、`license` と `description` が無い旨の警告が出ます（この PR より前からの状態です）。

## 確認手順

1. 本 PR の変更ファイル（`.github/dependabot.yml`、`.github/workflows/dependabot-auto-merge.yml`、`.github/workflows/dependabot-auto-merge-complete.yml`）の YAML が読める形であること（judge / complete は Dependabot の PR でしか動かないため、本 PR 上では動作しない）
   → 手元で `python3 -c 'import yaml,sys; [yaml.safe_load(open(f)) for f in sys.argv[1:]]; print("ok")' <上記 3 ファイル>` を実行すると `ok` が出る
2. `dependabot-auto-merge-complete.yml` の `workflows:` に書いた名前が `php_unit_test.yml` の `name:` と一致していること
   → どちらも `PHP Unit Test`
3. 本 PR の `PHP Unit Test`（6 ジョブ）が通ること
   → `composer.json` の platform 設定を入れた状態で `composer install` と `npm run build` と PHPUnit が通る
4. マージ後、Dependabot の自動 PR 作成（security updates）を有効化する（司が行う）
5. 最初に作られた Dependabot の PR で以下を確認する
   - `Dependabot auto-merge` ワークフローのログに判定結果と理由が出ている
   - 自動マージ対象なら `dependabot-auto-merge` ラベルが付いている
   - ゲート CI（`PHP Unit Test`）が `run-ci` ラベル無しで動いている
   - CI 成功後に `Dependabot auto-merge complete` が動き、PR がマージされている
6. 人が作った PR では従来どおり `PHP Unit Test` が動くこと（このリポジトリではもともと `run-ci` ラベル無しで動く作りのため、変化はない）

@coderabbitai ignore
