### PR TITLE
[ 開発環境 ] wp-env の起動失敗で PHP Unit Test が落ち続けるため、Dependabot 自動マージのゲート CI を wp-env に依存しない Dependabot CI に変更

### DIFF
--- a/.github/workflows/dependabot-auto-merge-complete.yml
+++ b/.github/workflows/dependabot-auto-merge-complete.yml
@@ -7,7 +7,7 @@ name: Dependabot auto-merge complete
 on:
   workflow_run:
     workflows:
-      - "PHP Unit Test"
+      - "Dependabot CI"
     types:
       - completed
 

--- a/.github/workflows/dependabot-ci.yml
+++ b/.github/workflows/dependabot-ci.yml
@@ -1,0 +1,44 @@
+# Dependabot の PR に対して、依存関係のインストールとビルドが通るかを確認する軽量な CI。
+# dependabot-auto-merge-complete.yml がこのワークフローの成功を見てマージする。
+#
+# PHP Unit Test（wp-env で WordPress を起動する）は全 PR で動くが、wp-env の Docker イメージの
+# ビルド失敗など環境要因で落ちることがあるため、マージの条件にはせずこちらを見る。
+# 人が作った PR ではこのワークフローは動かない。
+name: Dependabot CI
+
+on:
+  pull_request:
+    branches:
+      - master
+    # labeled を含めない。Dependabot は PR 作成直後に dependencies などのラベルを
+    # 次々に付けるため、含めるとそのたびに起動して同じ内容を何度もビルドする。
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+
+      - name: Setup PHP 7.4
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+
+      - name: Install npm packages
+        run: npm install
+
+      - name: Install Composer packages
+        run: composer install --no-interaction --prefer-dist
+
+      # npm run build は gulp compile（SCSS のコンパイル）だけで、WP-CLI や wp-env は使わない
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
Refs https://github.com/vektor-inc/multi-repo-tasks/issues/42（Dependabot の自動マージのしくみを各リポジトリへ展開する issue）

## 概要

#367（Dependabot の PR を CI 通過後に自動マージするしくみの導入）では、全 PR で動いている既存の `PHP Unit Test` をマージ条件（ゲート CI）にしました。ところがこのワークフローは 2026-09-05 から master でも失敗しています。wp-env（テスト用 WordPress を Docker で起動するツール）の Docker イメージのビルド中に `apt-get -qy install sudo` がエラー（exit code 100）になるためで、本リポジトリのコードとは無関係の環境要因です。

このままだと、開発依存の安全な更新も 1 件もマージされません。

## 何がどう変わるか

- `.github/workflows/dependabot-ci.yml` を新設しました。他のリポジトリと同じく Dependabot の PR だけで動き、Node（`.node-version` の 20.14.0）と PHP 7.4 で `npm install`・`composer install`・`npm run build`（gulp compile による SCSS のコンパイル）までを確認します。wp-env は使いません
- `dependabot-auto-merge-complete.yml`（CI 成功後にマージするワークフロー）が見るワークフロー名を `PHP Unit Test` から `Dependabot CI` に変えました

`PHP Unit Test` は従来どおり全 PR で動きますが、マージの条件からは外れます。

## 気づいた点（この PR では変更しない）

`PHP Unit Test` の wp-env 起動失敗は別途対応が要ります。`@wordpress/env` 11.10.0 が使う Docker イメージの apt リポジトリ側の問題と思われます。

## 確認手順

1. マージ後、open の Dependabot PR で `@dependabot recreate` を実行し、`Dependabot CI` が起動して成功すること
2. `dependabot-auto-merge` ラベルの付いた PR が、CI 成功後に `Dependabot auto-merge complete` でマージされること

@coderabbitai ignore
