### PR TITLE
[ 開発環境 ] PHP Unit Test が wp-env の Docker ビルドで落ち続ける問題を修正

### DIFF
--- a/.github/workflows/php_unit_test.yml
+++ b/.github/workflows/php_unit_test.yml
@@ -17,6 +17,8 @@ jobs:
     php_unit:
         runs-on: ubuntu-latest
         strategy:
+            # 1 つの組み合わせが失敗しても残りを最後まで回し、どの環境で失敗したかを見えるようにする
+            fail-fast: false
             matrix:
                 php-versions: ['7.4', '8.0', '8.2']
                 wp-versions: ['6.7', '6.8']
@@ -26,7 +28,7 @@ jobs:
               with:
                   persist-credentials: false
             - name: Read .node-version
-              run: echo "{NODEVERSION}={$(cat .node-version)}" >> $GITHUB_OUTPUT
+              run: echo "NODEVERSION=$(cat .node-version)" >> $GITHUB_OUTPUT
               id: nodenv
             - name: Setup Node.js (.node-version)
               uses: actions/setup-node@v4
@@ -50,6 +52,12 @@ jobs:
                   curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
                   chmod +x wp-cli.phar
                   mv wp-cli.phar /usr/local/bin/wp
+            - name: '[debug] WordPress イメージ上で apt が動くか確認'
+              run: |
+                  docker run --rm wordpress:php${{ matrix.php-versions }} sh -c '
+                    cat /etc/os-release | grep -E "^(PRETTY_NAME|VERSION_CODENAME)";
+                    apt-get clean; apt-get -qy update; echo "update exit=$?";
+                    apt-get -qy install sudo; echo "sudo exit=$?"' || true
             - name: Install several WordPress version by wp-env.override.json
               run: WP_ENV_PHP_VERSION=${{ matrix.php-versions }} WP_ENV_CORE=WordPress/WordPress#${{ matrix.wp-versions }} npm run wp-env start --update
             - name: Check WordPress Version

--- a/.github/workflows/php_unit_test.yml
+++ b/.github/workflows/php_unit_test.yml
@@ -20,7 +20,11 @@ jobs:
             # 1 つの組み合わせが失敗しても残りを最後まで回し、どの環境で失敗したかを見えるようにする
             fail-fast: false
             matrix:
-                php-versions: ['7.4', '8.0', '8.2']
+                # PHP 7.4 / 8.0 の WordPress 公式イメージは Debian 11（bullseye）製で、
+                # bullseye の LTS 終了（2026-08-31）後にセキュリティリポジトリから
+                # パッケージが消え、wp-env の Docker ビルド（sudo のインストール）が失敗する。
+                # 保守されているイメージ（Debian 13 製）がある 8.1 以上でテストする。
+                php-versions: ['8.1', '8.2', '8.3']
                 wp-versions: ['6.7', '6.8']
         name: PHP Unit Test on PHP ${{ matrix.php-versions }} / WP ${{ matrix.wp-versions }}
         steps:
@@ -52,12 +56,6 @@ jobs:
                   curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
                   chmod +x wp-cli.phar
                   mv wp-cli.phar /usr/local/bin/wp
-            - name: '[debug] WordPress イメージ上で apt が動くか確認'
-              run: |
-                  docker run --rm wordpress:php${{ matrix.php-versions }} sh -c '
-                    cat /etc/os-release | grep -E "^(PRETTY_NAME|VERSION_CODENAME)";
-                    apt-get clean; apt-get -qy update; echo "update exit=$?";
-                    apt-get -qy install sudo; echo "sudo exit=$?"' || true
             - name: Install several WordPress version by wp-env.override.json
               run: WP_ENV_PHP_VERSION=${{ matrix.php-versions }} WP_ENV_CORE=WordPress/WordPress#${{ matrix.wp-versions }} npm run wp-env start --update
             - name: Check WordPress Version


### PR DESCRIPTION
関連 issue: https://github.com/vektor-inc/multi-repo-tasks/issues/42 （Dependabot の自動マージのしくみを各リポジトリへ展開する issue。本 PR はその後始末の 1 件で、issue 自体は閉じない）

## 概要

`PHP Unit Test` ワークフロー（wp-env で WordPress を Docker 上に立ち上げて PHPUnit を実行する CI）が、2026-09-05 以降 master でも失敗し続けていました。原因を特定し、テスト対象のコンテナ PHP を保守中の Docker イメージがあるバージョンに変更して直します。

## 原因

wp-env は WordPress 公式の Docker イメージ（`wordpress:php7.4` など）に `sudo` を追加インストールします。PHP 7.4 / 8.0 のイメージは Debian 11（bullseye）製で、bullseye の LTS（長期サポート）が 2026-08-31 に終了したあと、セキュリティ更新のリポジトリからパッケージが消え始めており、次のエラーで止まります。

```
E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/s/sudo/sudo_1.9.5p2-3+deb11u4_amd64.deb  404  Not Found
```

配信 CDN のエッジによって残っている場所と消えた場所があるため、同じ PHP 8.0 でも WP 6.8 のジョブは成功し WP 6.7 のジョブは失敗する、という不安定な状態でした（本 PR の 1 回目の run で、fail-fast を切って全マトリクスを回し、イメージ上で直接 `apt-get install sudo` を実行して確認）。PHP 8.2 のイメージ（Debian 13 trixie 製）は 2 件とも成功しています。

依存ライブラリの更新内容とは無関係で、手元の Docker では再現しません（手元からアクセスする CDN エッジにはまだファイルが残っているため）。

## 何がどう変わるか

| 項目 | 変更前 | 変更後 |
|---|---|---|
| テスト対象のコンテナ PHP（`matrix.php-versions`） | 7.4 / 8.0 / 8.2 | **8.1 / 8.2 / 8.3** |
| `fail-fast` | 既定（true。1 つ失敗すると残りを取り消す） | **false**（どの組み合わせで失敗したかが見えるようにする） |
| `.node-version` を読むステップ | 出力名が `{NODEVERSION}={...}` と書き間違っており値が渡らず、ランナー既定の Node で動いていた | `NODEVERSION=...` に修正し、`.node-version` の 20.14.0 が使われる |

PHP 7.4 / 8.0 を外すのは、wp-env が使う公式イメージがもう保守されておらず、CI でテストできなくなったためです。PHP の下限サポートの方針そのものは変えていません（`composer.json` の `config.platform.php` は 7.4 のまま）。PHP 7.4 / 8.0 での実行確認が必要な場合は、wp-env 以外の方法（別の Docker イメージや実サーバー）が要ります。

## 確認手順

1. 本 PR の `PHP Unit Test` で、PHP 8.1 / 8.2 / 8.3 × WP 6.7 / 6.8 の 6 ジョブがすべて成功する
2. `Setup Node.js (.node-version)` ステップのログで Node 20.14.0 が使われている
3. マージ後、open の Dependabot PR に `@dependabot rebase` を送り、`PHP Unit Test` が成功に変わる

@coderabbitai ignore
